### PR TITLE
Add Intents for starting and stopping logging (for automation)

### DIFF
--- a/GPSLogger/AndroidManifest.xml
+++ b/GPSLogger/AndroidManifest.xml
@@ -87,6 +87,17 @@
         </receiver>
 
         <receiver android:name="com.mendhak.gpslogger.senders.AlarmReceiver"/>
+        
+        <receiver
+            android:name="com.mendhak.gpslogger.ExternalControlReceiver"
+            android:enabled="true"
+            android:exported="true" >
+            <intent-filter>
+                <action android:name="com.mendhak.gpslogger.STARTL" />
+                <action android:name="com.mendhak.gpslogger.STOPL" />
+            </intent-filter>
+        </receiver>
+        
     </application>
     <uses-sdk android:minSdkVersion="5" android:targetSdkVersion="5"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>

--- a/GPSLogger/src/com/mendhak/gpslogger/ExternalControlReceiver.java
+++ b/GPSLogger/src/com/mendhak/gpslogger/ExternalControlReceiver.java
@@ -1,0 +1,27 @@
+package com.mendhak.gpslogger;
+
+import com.mendhak.gpslogger.common.Session;
+import com.mendhak.gpslogger.common.Utilities;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+public class ExternalControlReceiver extends BroadcastReceiver {
+
+	@Override
+	public void onReceive(Context context, Intent intent) {
+
+		if ("com.mendhak.gpslogger.STARTL".equals(intent.getAction())) {
+			Utilities.LogInfo("Go Go Go");
+			Intent serviceIntent = new Intent(context, GpsLoggingService.class);
+			serviceIntent.putExtra("immediate", true);
+			context.startService(serviceIntent);
+		}
+		if ("com.mendhak.gpslogger.STOPL".equals(intent.getAction())) {
+			Utilities.LogInfo("Stop Stop Stop");
+			Session.setStarted(false);
+		}
+	}
+
+}


### PR DESCRIPTION
I have approximately zero experience writing android code, but here is my attempt for issues #32 #71 #105 #108

This adds these custom broadcast intent actions that will start or stop the logging respectively 
com.mendhak.gpslogger.STARTL
com.mendhak.gpslogger.STOPL

I'm not sure if it is the correct way to do it, but for me it allows me to use an app like _Llama_ to control the starting and stopping of logging.
