### PR TITLE
Support travelled distance in GPSLogger main screen

### DIFF
--- a/GPSLogger/res/layout/main.xml
+++ b/GPSLogger/res/layout/main.xml
@@ -70,6 +70,12 @@
                 <TextView android:id="@+id/txtAccuracy" android:gravity="left"
                           android:padding="3dip"/>
             </TableRow>
+            <TableRow android:background="#333333" android:layout_margin="1dip">
+                <TextView android:id="@+id/lblDistance" android:textStyle="bold"
+                          android:text="@string/txt_travel_distance" android:padding="3dip"/>
+                <TextView android:id="@+id/txtDistanceTravelled" android:gravity="left"
+                          android:padding="3dip"/>
+            </TableRow>
         </TableLayout>
 
 

--- a/GPSLogger/res/values/strings.xml
+++ b/GPSLogger/res/values/strings.xml
@@ -33,6 +33,8 @@
     <string name="txt_direction">Direction:</string>
     <string name="txt_satellites">Satellites:</string>
     <string name="txt_accuracy">Accuracy:</string>
+    <string name="txt_distance">Distance:</string>
+    <string name="txt_travel_distance">Travelled:</string>
     <string name="btn_start_logging">Start Logging</string>
     <string name="btn_stop_logging">Stop Logging</string>
 
@@ -82,7 +84,9 @@
     <string name="meters_per_second">&#160;m/s</string>
     <string name="feet_per_second">&#160;ft/s</string>
     <string name="miles_per_hour">&#160;mi/h</string>
+    <string name="miles">&#160;mi</string>
     <string name="kilometers_per_hour">&#160;km/h</string>
+    <string name="kilometers">&#160;km</string>
     <string name="unknown_direction">unknown</string>
     <string name="deleted">Deleted</string>
 

--- a/GPSLogger/src/com/mendhak/gpslogger/common/Session.java
+++ b/GPSLogger/src/com/mendhak/gpslogger/common/Session.java
@@ -21,6 +21,9 @@ public class Session extends Application
 	private static long latestTimeStamp;
 	private static boolean addNewTrackSegment = true;
 	private static Location currentLocationInfo;
+    private static Location previousLocationInfo;
+    private static double totalTravelled;
+    private static int numLegs;
 	private static boolean isBound;
 	private static boolean readyToBeAutoSent =false;
 	private static boolean allowDescription = true;
@@ -173,7 +176,44 @@ public class Session extends Application
 		}
 	}
 
-	/**
+    public static double getPreviousLatitude() {
+        Location loc = getPreviousLocationInfo();
+        return loc != null ? loc.getLatitude() : 0;
+    }
+
+    public static double getPreviousLongitude() {
+        Location loc = getPreviousLocationInfo();
+        return loc != null ? loc.getLongitude() : 0;
+    }
+
+    public static double getTotalTravelled() {
+        return totalTravelled;
+    }
+
+    public static int getNumLegs() {
+        return numLegs;
+    }
+
+    public static void setTotalTravelled(double totalTravelled) {
+        if (totalTravelled == 0 ) {
+            Session.numLegs = 0;
+        } else {
+            Session.numLegs++;
+        }
+        Session.totalTravelled = totalTravelled;
+    }
+
+    public static Location getPreviousLocationInfo() {
+        return previousLocationInfo;
+    }
+
+    public static void setPreviousLocationInfo(Location previousLocationInfo) {
+        Session.previousLocationInfo = previousLocationInfo;
+    }
+
+
+
+    /**
 	 * Determines whether a valid location is available
 	 */
 	public static boolean hasValidLocation()


### PR DESCRIPTION
Supports:
1. Units toggle between Imperial and Metric
2. Has threshold to display smaller vs larger distance units
3. Running total of travelled distance is calculated based on valid location way points instead of start to end locations.
