### PR TITLE
Show error message if there is no network on uploading files

### DIFF
--- a/gpslogger/src/main/AndroidManifest.xml
+++ b/gpslogger/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:allowBackup="true"

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/GpsMainActivity.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/GpsMainActivity.java
@@ -19,7 +19,6 @@ package com.mendhak.gpslogger;
 
 import android.app.ActionBar;
 import android.app.Activity;
-
 import android.app.Fragment;
 import android.app.FragmentManager;
 import android.app.FragmentTransaction;
@@ -42,10 +41,19 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.WindowManager;
-import android.widget.*;
+import android.widget.ArrayAdapter;
+import android.widget.EditText;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.ProgressBar;
+import android.widget.SpinnerAdapter;
+import android.widget.TextView;
+import android.widget.Toast;
+
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.mendhak.gpslogger.common.AppSettings;
 import com.mendhak.gpslogger.common.IActionListener;
+import com.mendhak.gpslogger.common.NetworkUtils;
 import com.mendhak.gpslogger.common.Session;
 import com.mendhak.gpslogger.common.Utilities;
 import com.mendhak.gpslogger.senders.FileSenderFactory;
@@ -66,13 +74,17 @@ import com.mendhak.gpslogger.views.GenericViewFragment;
 import com.mendhak.gpslogger.views.GpsBigViewFragment;
 import com.mendhak.gpslogger.views.GpsDetailedViewFragment;
 import com.mendhak.gpslogger.views.GpsSimpleViewFragment;
+
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.InputStreamReader;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Properties;
 
 public class GpsMainActivity extends Activity
         implements GenericViewFragment.IGpsViewCallback, NavigationDrawerFragment.NavigationDrawerCallbacks, ActionBar.OnNavigationListener, IGpsLoggerServiceClient, IActionListener {
@@ -513,6 +525,11 @@ public class GpsMainActivity extends Activity
             return;
         }
 
+        if (!NetworkUtils.isNetworkAvailable(this)) {
+            Utilities.MsgBox(getString(R.string.sorry),getString(R.string.no_network_message), this);
+            return;
+        }
+
         Intent settingsIntent = OSMHelper.GetOsmSettingsIntent(getApplicationContext());
         ShowFileListDialog(settingsIntent, FileSenderFactory.GetOsmSender(getApplicationContext(), this));
     }
@@ -523,6 +540,11 @@ public class GpsMainActivity extends Activity
         if (!dropBoxHelper.IsLinked()) {
             tracer.debug("Not linked, opening Dropbox activity");
             startActivity(new Intent("com.mendhak.gpslogger.DROPBOX_SETUP"));
+            return;
+        }
+
+        if (!NetworkUtils.isNetworkAvailable(this)) {
+            Utilities.MsgBox(getString(R.string.sorry),getString(R.string.no_network_message), this);
             return;
         }
 
@@ -549,6 +571,11 @@ public class GpsMainActivity extends Activity
             return;
         }
 
+        if (!NetworkUtils.isNetworkAvailable(this)) {
+            Utilities.MsgBox(getString(R.string.sorry),getString(R.string.no_network_message), this);
+            return;
+        }
+
         Intent settingsIntent = new Intent(GpsMainActivity.this, GDocsSettingsActivity.class);
         ShowFileListDialog(settingsIntent, FileSenderFactory.GetGDocsSender(getApplicationContext(), this));
     }
@@ -560,9 +587,12 @@ public class GpsMainActivity extends Activity
             tracer.debug("Not setup, opening FTP setup activity");
             startActivity(settingsIntent);
         } else {
+            if (!NetworkUtils.isNetworkAvailable(this)) {
+                Utilities.MsgBox(getString(R.string.sorry),getString(R.string.no_network_message), this);
+                return;
+            }
             IFileSender fs = FileSenderFactory.GetFtpSender(getApplicationContext(), this);
             ShowFileListDialog(settingsIntent, fs);
-
         }
     }
 
@@ -573,6 +603,10 @@ public class GpsMainActivity extends Activity
             tracer.debug("Not set up, opening email setup activity");
             startActivity(settingsIntent);
         } else {
+            if (!NetworkUtils.isNetworkAvailable(this)) {
+                Utilities.MsgBox(getString(R.string.sorry),getString(R.string.no_network_message), this);
+                return;
+            }
             ShowFileListDialog(settingsIntent, FileSenderFactory.GetEmailSender(this));
         }
 

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/NetworkUtils.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/NetworkUtils.java
@@ -1,0 +1,28 @@
+package com.mendhak.gpslogger.common;
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+
+public class NetworkUtils {
+    /**
+     * returns information on the active network connection
+     */
+    private static NetworkInfo getActiveNetworkInfo(Context context) {
+        if (context == null) {
+            return null;
+        }
+        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (cm == null) {
+            return null;
+        }
+        // note that this may return null if no network is currently active
+        return cm.getActiveNetworkInfo();
+    }
+
+    public static boolean isNetworkAvailable(Context context) {
+        NetworkInfo info = getActiveNetworkInfo(context);
+        return (info != null && info.isConnected());
+    }
+
+}

--- a/gpslogger/src/main/res/values/strings.xml
+++ b/gpslogger/src/main/res/values/strings.xml
@@ -481,4 +481,5 @@
     <string name="donate_app">Donate (app)</string>
     <string name="donate_bitcoin">Donate (Bitcoin)</string>
 
+    <string name="no_network_message">There is no network available</string>
 </resources>


### PR DESCRIPTION
Currently gpslogger uploads file no matter the connectivity is available or not. The "please wait" progress dialog is confusing.  
The patch checks the network connections before sending, and shows "There is no network available" msg box if it is not connected. 
