### PR TITLE
Add timeout for http requests

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/OpenGTSClient.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/OpenGTSClient.java
@@ -85,6 +85,8 @@ public class OpenGTSClient {
 
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
+			conn.setConnectTimeout(10000);
+		    conn.setReadTimeout(30000);
 
             Scanner s;
             if(conn.getResponseCode() != 200){

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/gdocs/GDocsJob.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/gdocs/GDocsJob.java
@@ -12,7 +12,7 @@ import com.mendhak.gpslogger.common.Utilities;
 import com.mendhak.gpslogger.common.events.UploadEvents;
 import com.path.android.jobqueue.Job;
 import com.path.android.jobqueue.Params;
-import de.greenrobot.event.EventBus;
+
 import org.json.JSONObject;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +22,8 @@ import java.io.FileInputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+
+import de.greenrobot.event.EventBus;
 
 public class GDocsJob extends Job {
     private static final org.slf4j.Logger tracer = LoggerFactory.getLogger(GDocsJob.class.getSimpleName());
@@ -120,6 +122,9 @@ public class GDocsJob extends Job {
             conn.setDoInput(true);
             conn.setDoOutput(true);
 
+			conn.setConnectTimeout(10000);
+			conn.setReadTimeout(30000);
+
             DataOutputStream wr = new DataOutputStream(
                     conn.getOutputStream());
             wr.write(fileContents);
@@ -180,6 +185,9 @@ public class GDocsJob extends Job {
             conn.setDoInput(true);
             conn.setDoOutput(true);
 
+			conn.setConnectTimeout(10000);
+			conn.setReadTimeout(30000);
+
             DataOutputStream wr = new DataOutputStream(
                     conn.getOutputStream());
             wr.writeBytes(createFilePayload);
@@ -236,7 +244,9 @@ public class GDocsJob extends Job {
             conn.setRequestMethod("GET");
             conn.setRequestProperty("User-Agent", "GPSLogger for Android");
             conn.setRequestProperty("Authorization", "OAuth " + authToken);
-
+			conn.setConnectTimeout(10000);
+			conn.setReadTimeout(30000);
+	
             String fileMetadata = Utilities.GetStringFromInputStream(conn.getInputStream());
 
 

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/osm/OSMJob.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/osm/OSMJob.java
@@ -3,8 +3,7 @@ package com.mendhak.gpslogger.senders.osm;
 import com.mendhak.gpslogger.common.events.UploadEvents;
 import com.path.android.jobqueue.Job;
 import com.path.android.jobqueue.Params;
-import de.greenrobot.event.EventBus;
-import oauth.signpost.OAuthConsumer;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.mime.HttpMultipartMode;
@@ -12,9 +11,14 @@ import org.apache.http.entity.mime.MultipartEntity;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.entity.mime.content.StringBody;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.params.HttpParams;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+
+import de.greenrobot.event.EventBus;
+import oauth.signpost.OAuthConsumer;
 
 public class OSMJob extends Job {
 
@@ -63,6 +67,9 @@ public class OSMJob extends Job {
 
         request.setEntity(entity);
         DefaultHttpClient httpClient = new DefaultHttpClient();
+		HttpParams params = httpClient.getParams();
+		HttpConnectionParams.setConnectionTimeout(params, 10000);
+		HttpConnectionParams.setSoTimeout(params, 30000);
 
         HttpResponse response = httpClient.execute(request);
         int statusCode = response.getStatusLine().getStatusCode();


### PR DESCRIPTION
Hi,

The timeout of HttpURLConnection and Apache HttpClient is 0, which means the request would never return if either connection or read timeouts, and the code would never catch these exceptions. 

This patch set explicit timeout value (10s for connection timeout and 30s for read timeout), so the code would catch and handle timeout exceptions as you would expect.

Best,