### PR TITLE
fix schema violation in gpx10 logger.

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/Gpx10FileLogger.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/Gpx10FileLogger.java
@@ -261,6 +261,14 @@ class Gpx10WriteHandler implements Runnable {
             track.append("<speed>").append(String.valueOf(loc.getSpeed())).append("</speed>");
         }
 
+        if (loc.getExtras() != null) {
+            String geoidheight = loc.getExtras().getString("GEOIDHEIGHT");
+
+            if (!Utilities.IsNullOrEmpty(geoidheight)) {
+                track.append("<geoidheight>").append(geoidheight).append("</geoidheight>");
+            }
+        }
+
         track.append("<src>").append(loc.getProvider()).append("</src>");
 
         if (satelliteCount > 0) {
@@ -271,7 +279,6 @@ class Gpx10WriteHandler implements Runnable {
             String hdop = loc.getExtras().getString("HDOP");
             String pdop = loc.getExtras().getString("PDOP");
             String vdop = loc.getExtras().getString("VDOP");
-            String geoidheight = loc.getExtras().getString("GEOIDHEIGHT");
             String ageofdgpsdata = loc.getExtras().getString("AGEOFDGPSDATA");
             String dgpsid = loc.getExtras().getString("DGPSID");
 
@@ -285,10 +292,6 @@ class Gpx10WriteHandler implements Runnable {
 
             if (!Utilities.IsNullOrEmpty(pdop)) {
                 track.append("<pdop>").append(pdop).append("</pdop>");
-            }
-
-            if (!Utilities.IsNullOrEmpty(geoidheight)) {
-                track.append("<geoidheight>").append(geoidheight).append("</geoidheight>");
             }
 
             if (!Utilities.IsNullOrEmpty(ageofdgpsdata)) {


### PR DESCRIPTION
The gpx 10 schema [http://www.topografix.com/GPX/1/0/gpx.xsd](url) requires a specific sequence for the elements contained in a trkpt:

                  <xsd:sequence>    <!-- elements must appear in this order -->
                    <xsd:element name="trkpt"   minOccurs="0" maxOccurs="unbounded">
                      <xsd:complexType>
                        <xsd:sequence>  <!-- elements must appear in this order -->

                          <!-- Position info -->
                          <xsd:element name="ele"           type="xsd:decimal"      minOccurs="0"/>
                          <xsd:element name="time"          type="xsd:dateTime"     minOccurs="0"/>
                          <xsd:element name="course"        type="gpx:degreesType"  minOccurs="0"/>
                          <xsd:element name="speed"         type="xsd:decimal"      minOccurs="0"/>
                          <xsd:element name="magvar"        type="gpx:degreesType"  minOccurs="0"/>
                          <xsd:element name="geoidheight"   type="xsd:decimal"      minOccurs="0"/>

                          <!-- Description info -->
                          <xsd:element name="name"          type="xsd:string"       minOccurs="0"/>
                          <xsd:element name="cmt"           type="xsd:string"       minOccurs="0"/>
                          <xsd:element name="desc"          type="xsd:string"       minOccurs="0"/>
                          <xsd:element name="src"           type="xsd:string"       minOccurs="0"/>
                          <xsd:element name="url"           type="xsd:anyURI"       minOccurs="0"/>
                          <xsd:element name="urlname"       type="xsd:string"       minOccurs="0"/>
                          <xsd:element name="sym"           type="xsd:string"       minOccurs="0"/>
                          <xsd:element name="type"          type="xsd:string"       minOccurs="0"/>

                          <!-- Accuracy info -->
                          <xsd:element name="fix"           type="gpx:fixType"      minOccurs="0"/>
                          <xsd:element name="sat"           type="xsd:nonNegativeInteger"   minOccurs="0"/>
                          <xsd:element name="hdop"          type="xsd:decimal"      minOccurs="0"/>
                          <xsd:element name="vdop"          type="xsd:decimal"      minOccurs="0"/>
                          <xsd:element name="pdop"          type="xsd:decimal"      minOccurs="0"/>
                          <xsd:element name="ageofdgpsdata" type="xsd:decimal"      minOccurs="0"/>
                          <xsd:element name="dgpsid"        type="gpx:dgpsStationType"      minOccurs="0"/>

                          <!-- you can add your own privately defined trkpt elements at the end of the trkpt -->
                          <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
                        </xsd:sequence>


