### PR TITLE
fix error in parsing nmea sentences to get hdop.

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/nmea/NmeaSentence.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/nmea/NmeaSentence.java
@@ -44,8 +44,10 @@ public class NmeaSentence {
             }
         }
 
-        else if (nmeaParts.length > 16 &&!Utilities.IsNullOrEmpty(nmeaParts[16])) {
-            return nmeaParts[16];
+        else if (nmeaParts[0].equalsIgnoreCase("$GPGSA")) {
+            if (nmeaParts.length > 16 &&!Utilities.IsNullOrEmpty(nmeaParts[16])) {
+                return nmeaParts[16];
+            }
         }
 
         return null;


### PR DESCRIPTION
when parsing nmea sentences for hdop the type of sentence may not be qualified.

It looks like a recent bug was introduced in https://github.com/mendhak/gpslogger/commit/0589180e77e4758bad578fd520c3a3f8e0c989a4