### PR TITLE
Added 3 more placeholders for the custom file name generator.

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/Strings.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/Strings.java
@@ -263,7 +263,7 @@ public class Strings {
         finalFileName = finalFileName.replaceAll("(?i)%ver", String.valueOf(BuildConfig.VERSION_NAME));
         finalFileName = finalFileName.replaceAll("(?i)%hour", String.format("%02d", calendar.get(Calendar.HOUR_OF_DAY)));
         finalFileName = finalFileName.replaceAll("(?i)%min", String.format("%02d", calendar.get(Calendar.MINUTE)));
-        finalFileName = finalFileName.replaceAll("(?i)%sec", String.format("%02d", calendar.get(Calendar.SECOND));
+        finalFileName = finalFileName.replaceAll("(?i)%sec", String.format("%02d", calendar.get(Calendar.SECOND)));
         finalFileName = finalFileName.replaceAll("(?i)%year",  String.valueOf(calendar.get(Calendar.YEAR)));
         finalFileName = finalFileName.replaceAll("(?i)%monthname", new SimpleDateFormat("MMM", Locale.ENGLISH).format(calendar.getTime()).toLowerCase());
         finalFileName = finalFileName.replaceAll("(?i)%month", String.format("%02d", calendar.get(Calendar.MONTH) +1));

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/Strings.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/Strings.java
@@ -263,7 +263,6 @@ public class Strings {
         finalFileName = finalFileName.replaceAll("(?i)%ver", String.valueOf(BuildConfig.VERSION_NAME));
         finalFileName = finalFileName.replaceAll("(?i)%hour", String.format("%02d", calendar.get(Calendar.HOUR_OF_DAY)));
         finalFileName = finalFileName.replaceAll("(?i)%min", String.format("%02d", calendar.get(Calendar.MINUTE)));
-        finalFileName = finalFileName.replaceAll("(?i)%sec", String.format("%02d", calendar.get(Calendar.SECOND)));
         finalFileName = finalFileName.replaceAll("(?i)%year",  String.valueOf(calendar.get(Calendar.YEAR)));
         finalFileName = finalFileName.replaceAll("(?i)%monthname", new SimpleDateFormat("MMM", Locale.ENGLISH).format(calendar.getTime()).toLowerCase());
         finalFileName = finalFileName.replaceAll("(?i)%month", String.format("%02d", calendar.get(Calendar.MONTH) +1));

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/Strings.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/Strings.java
@@ -263,8 +263,11 @@ public class Strings {
         finalFileName = finalFileName.replaceAll("(?i)%ver", String.valueOf(BuildConfig.VERSION_NAME));
         finalFileName = finalFileName.replaceAll("(?i)%hour", String.format("%02d", calendar.get(Calendar.HOUR_OF_DAY)));
         finalFileName = finalFileName.replaceAll("(?i)%min", String.format("%02d", calendar.get(Calendar.MINUTE)));
+        finalFileName = finalFileName.replaceAll("(?i)%sec", String.format("%02d", calendar.get(Calendar.SECOND));
         finalFileName = finalFileName.replaceAll("(?i)%year",  String.valueOf(calendar.get(Calendar.YEAR)));
+        finalFileName = finalFileName.replaceAll("(?i)%monthname", new SimpleDateFormat("MMM", Locale.ENGLISH).format(calendar.getTime()).toLowerCase());
         finalFileName = finalFileName.replaceAll("(?i)%month", String.format("%02d", calendar.get(Calendar.MONTH) +1));
+        finalFileName = finalFileName.replaceAll("(?i)%dayname", new SimpleDateFormat("EE", Locale.ENGLISH).format(calendar.getTime()).toLowerCase());
         finalFileName = finalFileName.replaceAll("(?i)%day", String.format("%02d", calendar.get(Calendar.DAY_OF_MONTH) ));
         finalFileName = finalFileName.replaceAll("(?i)%profile", String.valueOf(ph.getCurrentProfileName()));
         return finalFileName;

--- a/gpslogger/src/main/res/values/strings.xml
+++ b/gpslogger/src/main/res/values/strings.xml
@@ -337,7 +337,7 @@
     <string name="gpslogger_folder_title">Save to folder</string>
     <string name="gpslogger_folder_summary">Where to save the log files to, defaults to /sdcard/GPSLogger</string>
     <string name="autoftp_directory">Folder</string>
-    <string name="new_file_custom_message">You can use %SER for device serial, %YEAR, %MONTH, %DAY, %HOUR, %MIN, %PROFILE, %VER for version</string>
+    <string name="new_file_custom_message">You can use %SER for device serial, %YEAR, %MONTH, %MONTHNAME, %DAY, %DAYNAME, %HOUR, %MIN, %PROFILE, %VER for version</string>
     <string name="new_file_prefix_serial_title">Prefix the device serial number to the file name</string>
     <string name="new_file_prefix_serial_summary">This is the serial number found in your phone status </string>
     <string name="txt_travel_duration">Duration:</string>

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/common/StringsTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/common/StringsTest.java
@@ -11,6 +11,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -180,6 +181,34 @@ public class StringsTest {
         assertThat("Profile replaced with profile name", actual, is(expected));
 
     }
+
+
+    @Test
+    public void getFormattedCustomFileName_DAYNAME_ReplaceWithThreeLetterDayName(){
+        PreferenceHelper ph = mock(PreferenceHelper.class);
+        GregorianCalendar greg = new GregorianCalendar();
+        greg.setTimeInMillis(1495663380828l); //24 May 2017
+
+        String actual = Strings.getFormattedCustomFileName("basename_%DAYNAME", greg, ph);
+        String expected = "basename_wed";
+
+        assertThat("Day name substituted in file name", actual, is(expected));
+    }
+
+    @Test
+    public void getFormattedCustomFileName_MONTHNAME_ReplaceWithThreeLetterDayName(){
+        PreferenceHelper ph = mock(PreferenceHelper.class);
+        GregorianCalendar greg = new GregorianCalendar();
+        greg.setTimeInMillis(1495663380828l); //24 May 2017
+
+        String actual = Strings.getFormattedCustomFileName("basename_%MONTHNAME", greg, ph);
+        String expected = "basename_may";
+
+        assertThat("Month name substituted in file name", actual, is(expected));
+    }
+
+
+
 
     private Context GetDescriptiveTimeString_Context(){
         Context ctx = mock(Context.class);


### PR DESCRIPTION
%SEC for seconds
%DAYNAME for the three letter month name (fixed to english language, lowercased)
%MONTHNAME for the three letter month name (fixed to english language, lowercased)

Filenames like "gps--2017-05-24--wed--20-32-07.csv" are easier to find in a file browser (where's the file from last monday afternoon?).