### PR TITLE
 Fix #544: undesired scrolling in detailed view

### DIFF
--- a/gpslogger/src/main/res/layout/fragment_detailed_view.xml
+++ b/gpslogger/src/main/res/layout/fragment_detailed_view.xml
@@ -8,7 +8,8 @@
     <LinearLayout
         android:orientation="vertical"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:descendantFocusability="blocksDescendants" >
 
         <android.support.v7.widget.CardView
             xmlns:card_view="http://schemas.android.com/apk/res-auto"


### PR DESCRIPTION
I've fixed the behaviour described in issue #544 by adding a matching property to the relevant part of the fragments manifest.