### PR TITLE
CSV logger can save annotations

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/GpsLoggingService.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/GpsLoggingService.java
@@ -1012,7 +1012,7 @@ public class GpsLoggingService extends Service  {
 
     @EventBusHook
     public void onEvent(CommandEvents.Annotate annotate){
-        final String desc = Strings.cleanDescription(annotate.annotation);
+        final String desc = annotate.annotation;
         if (desc.length() == 0) {
             LOG.debug("Clearing annotation");
             session.clearDescription();

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/GpsMainActivity.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/GpsMainActivity.java
@@ -777,7 +777,7 @@ public class GpsMainActivity extends AppCompatActivity
 
         if (mnuAnnotate != null) {
 
-            if (!preferenceHelper.shouldLogToGpx() && !preferenceHelper.shouldLogToKml() && !preferenceHelper.shouldLogToCustomUrl()) {
+            if (!preferenceHelper.shouldLogToCSV() && !preferenceHelper.shouldLogToGpx() && !preferenceHelper.shouldLogToKml() && !preferenceHelper.shouldLogToCustomUrl()) {
                 mnuAnnotate.setIcon(R.drawable.annotate2_disabled);
                 mnuAnnotate.setEnabled(false);
             } else {
@@ -866,7 +866,7 @@ public class GpsMainActivity extends AppCompatActivity
      */
     private void annotate() {
 
-        if (!preferenceHelper.shouldLogToGpx() && !preferenceHelper.shouldLogToKml() && !preferenceHelper.shouldLogToCustomUrl()) {
+        if (!preferenceHelper.shouldLogToCSV() && !preferenceHelper.shouldLogToGpx() && !preferenceHelper.shouldLogToKml() && !preferenceHelper.shouldLogToCustomUrl()) {
             Toast.makeText(getApplicationContext(), getString(R.string.annotation_requires_logging), Toast.LENGTH_SHORT).show();
             return;
         }

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/csv/CSVFileLogger.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/csv/CSVFileLogger.java
@@ -52,6 +52,10 @@ public class CSVFileLogger implements FileLogger {
         }
     }
 
+    String getCsvLine(Location loc, String dateTimeString) {
+        return getCsvLine("", loc, dateTimeString);
+    }
+
     String getCsvLine(String description, Location loc, String dateTimeString) {
 
         if (description.length() > 0) {

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/csv/CSVFileLogger.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/csv/CSVFileLogger.java
@@ -22,7 +22,6 @@ package com.mendhak.gpslogger.loggers.csv;
 import android.location.Location;
 import android.support.annotation.Nullable;
 import com.mendhak.gpslogger.common.Maths;
-import com.mendhak.gpslogger.common.Session;
 import com.mendhak.gpslogger.common.Strings;
 import com.mendhak.gpslogger.loggers.FileLogger;
 import com.mendhak.gpslogger.loggers.Files;
@@ -47,9 +46,7 @@ public class CSVFileLogger implements FileLogger {
 
     @Override
     public void write(Location loc) throws Exception {
-        if (!Session.getInstance().hasDescription()) {
             annotate("", loc);
-        }
     }
 
     String getCsvLine(Location loc, String dateTimeString) {

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/gpx/Gpx10FileLogger.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/gpx/Gpx10FileLogger.java
@@ -63,7 +63,9 @@ public class Gpx10FileLogger implements FileLogger {
     }
 
     public void annotate(String description, Location loc) throws Exception {
-
+        
+        description = Strings.cleanDescription(description);
+        
         long time = loc.getTime();
         if (time <= 0) {
             time = System.currentTimeMillis();

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/kml/Kml22FileLogger.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/kml/Kml22FileLogger.java
@@ -54,6 +54,9 @@ public class Kml22FileLogger implements FileLogger {
     }
 
     public void annotate(String description, Location loc) throws Exception {
+        
+        description = Strings.cleanDescription(description);
+        
         Kml22AnnotateHandler annotateHandler = new Kml22AnnotateHandler(kmlFile, description, loc);
         EXECUTOR.execute(annotateHandler);
     }

--- a/gpslogger/src/main/res/values-cs/strings.xml
+++ b/gpslogger/src/main/res/values-cs/strings.xml
@@ -232,7 +232,7 @@
   <string name="txt_annotation">Poznámka:</string>
   <string name="txt_time_isoformat">Čas UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Poskytovatel:</string>
-  <string name="annotation_requires_logging">Poznámky vyžadují záznam do GPX, KML nebo Vlastní URL</string>
+  <string name="annotation_requires_logging">Poznámky vyžadují záznam do CSV, GPX, KML nebo Vlastní URL</string>
   <string name="gpslogger_folder_title">Uložit do složky</string>
   <string name="gpslogger_folder_summary">Kam uložit soubory záznamů, výchozí hodnota je /sdcard/GPSLogger</string>
   <string name="autoftp_directory">Složka</string>

--- a/gpslogger/src/main/res/values-da/strings.xml
+++ b/gpslogger/src/main/res/values-da/strings.xml
@@ -247,7 +247,7 @@ præcision ved lavere frekvenser.    </string>
   <string name="txt_annotation">Anmærkning:</string>
   <string name="txt_time_isoformat">Tid UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Udbyder:</string>
-  <string name="annotation_requires_logging">Anmærkninger kræver logføring til GPX/KML/Tilpasset URL</string>
+  <string name="annotation_requires_logging">Anmærkninger kræver logføring til CSV/GPX/KML/Tilpasset URL</string>
   <string name="gpslogger_folder_title">Gem til mappe</string>
   <string name="gpslogger_folder_summary">Hvor logfiler skal gemmes, standarddestination er /sdcard/GPSLogger</string>
   <string name="autoftp_directory">Mappe</string>

--- a/gpslogger/src/main/res/values-de/strings.xml
+++ b/gpslogger/src/main/res/values-de/strings.xml
@@ -234,7 +234,7 @@
   <string name="txt_annotation">Anmerkung:</string>
   <string name="txt_time_isoformat">Zeit UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Anbieter:</string>
-  <string name="annotation_requires_logging">Anmerkungen sind vorgesehen für Aufzeichnung in GPX oder KML-format bzw. für benutzerdefinierte URLs</string>
+  <string name="annotation_requires_logging">Anmerkungen sind vorgesehen für Aufzeichnung in CSV, GPX oder KML-format bzw. für benutzerdefinierte URLs</string>
   <string name="gpslogger_folder_title">In Ordner speichern</string>
   <string name="gpslogger_folder_summary">Wo soll das Protokoll gespeichert werden, normalerweise in /sdcard/GPSLogger</string>
   <string name="autoftp_directory">Ordner</string>

--- a/gpslogger/src/main/res/values-es-rES/strings.xml
+++ b/gpslogger/src/main/res/values-es-rES/strings.xml
@@ -231,7 +231,7 @@
   <string name="txt_annotation">Comentarios:</string>
   <string name="txt_time_isoformat">Hora UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Proveedor:</string>
-  <string name="annotation_requires_logging">Para usar anotaciones es necesario registrar en formato GPX/KML ó URL personalizada</string>
+  <string name="annotation_requires_logging">Para usar anotaciones es necesario registrar en formato CSV/GPX/KML ó URL personalizada</string>
   <string name="gpslogger_folder_title">Guardar en carpeta</string>
   <string name="gpslogger_folder_summary">Donde guardar los archivos de registro, por defecto en «/sdcard/GPSLogger»</string>
   <string name="autoftp_directory">Carpeta</string>

--- a/gpslogger/src/main/res/values-fi/strings.xml
+++ b/gpslogger/src/main/res/values-fi/strings.xml
@@ -227,7 +227,7 @@
   <string name="txt_annotation">Huomautus:</string>
   <string name="txt_time_isoformat">Aika UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Tarjoaja:</string>
-  <string name="annotation_requires_logging">Huomautukset vaativat lokikirjauksen muotoon GPX/KML/Muokattu URL</string>
+  <string name="annotation_requires_logging">Huomautukset vaativat lokikirjauksen muotoon CSV/GPX/KML/Muokattu URL</string>
   <string name="gpslogger_folder_title">Tallenna kansioon</string>
   <string name="autoftp_directory">Kansio</string>
   <string name="txt_travel_duration">Kesto:</string>

--- a/gpslogger/src/main/res/values-fr/strings.xml
+++ b/gpslogger/src/main/res/values-fr/strings.xml
@@ -235,7 +235,7 @@ une plus grande précision à basses fréquences.    </string>
   <string name="txt_annotation">Annotation :</string>
   <string name="txt_time_isoformat">Heure UTC (2011-12-25T15:27:33Z) :</string>
   <string name="txt_provider">Fournisseur :</string>
-  <string name="annotation_requires_logging">Les annotations nécessitent l\'enregistrement en GPX/KML/URL personnalisée</string>
+  <string name="annotation_requires_logging">Les annotations nécessitent l\'enregistrement en CSV/GPX/KML/URL personnalisée</string>
   <string name="gpslogger_folder_title">Enregistrer dans le dossier</string>
   <string name="gpslogger_folder_summary">Où enregistrer les fichiers, par défaut dans /sdcard/GPSLogger</string>
   <string name="autoftp_directory">Dossier</string>

--- a/gpslogger/src/main/res/values-hr/strings.xml
+++ b/gpslogger/src/main/res/values-hr/strings.xml
@@ -229,7 +229,7 @@
   <string name="txt_annotation">Obilježavanje:</string>
   <string name="txt_time_isoformat">UTC vrijeme (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Pružatelj:</string>
-  <string name="annotation_requires_logging">Obilježavanje zahtijeva zapisivanje u GPX/KML/Prilagođen URL</string>
+  <string name="annotation_requires_logging">Obilježavanje zahtijeva zapisivanje u CSV/GPX/KML/Prilagođen URL</string>
   <string name="gpslogger_folder_title">Spremi u mapu</string>
   <string name="gpslogger_folder_summary">Gdje da sprema datoteku zapisivanja, zadano je/sdcard/GPSLogger</string>
   <string name="autoftp_directory">Mapa</string>

--- a/gpslogger/src/main/res/values-hu/strings.xml
+++ b/gpslogger/src/main/res/values-hu/strings.xml
@@ -233,7 +233,7 @@ Tetszés szerint adhat hozzá dinamikus paramétereket, mint a sorozatszám, év
   <string name="txt_annotation">Jegyzet:</string>
   <string name="txt_time_isoformat">UTC idő (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Szolgáltató:</string>
-  <string name="annotation_requires_logging">Széljegyzetekhez GPX, KML vagy saját URL logolás szükséges</string>
+  <string name="annotation_requires_logging">Széljegyzetekhez CSV, GPX, KML vagy saját URL logolás szükséges</string>
   <string name="gpslogger_folder_title">Mentés könyvtárba</string>
   <string name="gpslogger_folder_summary">Log fájlok mentési helye, /sdcard/GPSLogger az alapértelmezett</string>
   <string name="autoftp_directory">Mappa</string>

--- a/gpslogger/src/main/res/values-id/strings.xml
+++ b/gpslogger/src/main/res/values-id/strings.xml
@@ -234,7 +234,7 @@
   <string name="txt_annotation">Anotasi:</string>
   <string name="txt_time_isoformat">Waktu UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Penyedia:</string>
-  <string name="annotation_requires_logging">Anotasi butuh masuk ke GPX/KML/Kustom URL</string>
+  <string name="annotation_requires_logging">Anotasi butuh masuk ke CSV/GPX/KML/Kustom URL</string>
   <string name="gpslogger_folder_title">Simpan ke folder</string>
   <string name="gpslogger_folder_summary">Dimana untuk menyimpan catatan file ke, default ke/sdcard/GPSLogger</string>
   <string name="autoftp_directory">Folder</string>

--- a/gpslogger/src/main/res/values-it/strings.xml
+++ b/gpslogger/src/main/res/values-it/strings.xml
@@ -235,7 +235,7 @@
   <string name="txt_annotation">Annotazione:</string>
   <string name="txt_time_isoformat">Tempo UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Fornitore:</string>
-  <string name="annotation_requires_logging">Le annotazioni richiedono che sia attivato il salvataggio su GPX/KML/servercustom</string>
+  <string name="annotation_requires_logging">Le annotazioni richiedono che sia attivato il salvataggio su CSV/GPX/KML/servercustom</string>
   <string name="gpslogger_folder_title">Salva file nella cartella</string>
   <string name="gpslogger_folder_summary">Dove salvare i files, default in /sdcard/GPSLogger</string>
   <string name="autoftp_directory">Cartella</string>

--- a/gpslogger/src/main/res/values-ja/strings.xml
+++ b/gpslogger/src/main/res/values-ja/strings.xml
@@ -234,7 +234,7 @@
   <string name="txt_annotation">注釈:</string>
   <string name="txt_time_isoformat">UTC 時間 (2011-12-25T15:27:33Z)。</string>
   <string name="txt_provider">プロバイダー:</string>
-  <string name="annotation_requires_logging">GPX/KML/カスタム URLに保存する際の注釈</string>
+  <string name="annotation_requires_logging">CSV/GPX/KML/カスタム URLに保存する際の注釈</string>
   <string name="gpslogger_folder_title">フォルダーに保存します。</string>
   <string name="gpslogger_folder_summary">ログファイルの保存場所（デフォルト /sdcard/GPSLogger）</string>
   <string name="autoftp_directory">フォルダ</string>

--- a/gpslogger/src/main/res/values-nl/strings.xml
+++ b/gpslogger/src/main/res/values-nl/strings.xml
@@ -235,7 +235,7 @@
   <string name="txt_annotation">Aantekening:</string>
   <string name="txt_time_isoformat">UTC-tijd (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Provider:</string>
-  <string name="annotation_requires_logging">Aantekeningen maken vereist het loggen naar GPX/KML/gepersonaliseerd URL</string>
+  <string name="annotation_requires_logging">Aantekeningen maken vereist het loggen naar CSV/GPX/KML/gepersonaliseerd URL</string>
   <string name="gpslogger_folder_title">Opslaan in map</string>
   <string name="gpslogger_folder_summary">Locatie waar de logbestanden worden weggeschreven, standaardlocatie: /sdcard/GPSLogger</string>
   <string name="autoftp_directory">Map</string>

--- a/gpslogger/src/main/res/values-no/strings.xml
+++ b/gpslogger/src/main/res/values-no/strings.xml
@@ -219,7 +219,7 @@
   <string name="log_customurl_summary">Sende logg informasjon til din egen server over HTTP</string>
   <string name="txt_annotation">Merknad:</string>
   <string name="txt_provider">Tilbyder:</string>
-  <string name="annotation_requires_logging">Merknader krever logging til GPX/KML/Egendefinert URL</string>
+  <string name="annotation_requires_logging">Merknader krever logging til CSV/GPX/KML/Egendefinert URL</string>
   <string name="gpslogger_folder_title">Lagre i mappe</string>
   <string name="gpslogger_folder_summary">Hvor å lagre loggfiler, standard er /sdcard/GPSLogger</string>
   <string name="autoftp_directory">Mappe</string>

--- a/gpslogger/src/main/res/values-pl/strings.xml
+++ b/gpslogger/src/main/res/values-pl/strings.xml
@@ -227,7 +227,7 @@
   <string name="txt_annotation">Adnotacja:</string>
   <string name="txt_time_isoformat">Czas UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Dostawca:</string>
-  <string name="annotation_requires_logging">Adnotacje wymagają logowania do GPX/KML/niestandardowego URL</string>
+  <string name="annotation_requires_logging">Adnotacje wymagają logowania do CSV/GPX/KML/niestandardowego URL</string>
   <string name="gpslogger_folder_title">Zapisz w folderze</string>
   <string name="gpslogger_folder_summary">Gdzie zapisywać pliki logów; domyślnie do /sdcard/GPSLogger</string>
   <string name="autoftp_directory">Folder</string>

--- a/gpslogger/src/main/res/values-pt-rBR/strings.xml
+++ b/gpslogger/src/main/res/values-pt-rBR/strings.xml
@@ -238,7 +238,7 @@
   <string name="txt_annotation">Anotação:</string>
   <string name="txt_time_isoformat">Hora UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Provedor:</string>
-  <string name="annotation_requires_logging">Anotações exigem Log para GPX/KML/URL Personalizado</string>
+  <string name="annotation_requires_logging">Anotações exigem Log para CSV/GPX/KML/URL Personalizado</string>
   <string name="gpslogger_folder_title">Salvar na pasta</string>
   <string name="gpslogger_folder_summary">Onde deseja salvar os arquivos de log, padronizado para /sdcard/GPSLogger</string>
   <string name="autoftp_directory">Pasta</string>

--- a/gpslogger/src/main/res/values-pt-rPT/strings.xml
+++ b/gpslogger/src/main/res/values-pt-rPT/strings.xml
@@ -238,7 +238,7 @@ Nomes de ficheiro muito dinâmicos
   <string name="txt_annotation">Anotação:</string>
   <string name="txt_time_isoformat">Hora UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Fornecedor:</string>
-  <string name="annotation_requires_logging">Anotações exigem Log para GPX/KML/URL Personalizado</string>
+  <string name="annotation_requires_logging">Anotações exigem Log para CSV/GPX/KML/URL Personalizado</string>
   <string name="gpslogger_folder_title">Salvar na pasta</string>
   <string name="gpslogger_folder_summary">Onde deseja salvar os arquivos de log, para /sdcard/GPSLogger por omissão</string>
   <string name="autoftp_directory">Pasta</string>

--- a/gpslogger/src/main/res/values-ro/strings.xml
+++ b/gpslogger/src/main/res/values-ro/strings.xml
@@ -208,5 +208,5 @@
   <string name="txt_annotation">Adnotare:</string>
   <string name="txt_time_isoformat">Ora UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Furnizor:</string>
-  <string name="annotation_requires_logging">Adnotările necesita logare in GPX/KML/Custom URL</string>
+  <string name="annotation_requires_logging">Adnotările necesita logare in CSV/GPX/KML/Custom URL</string>
 </resources>

--- a/gpslogger/src/main/res/values-ru/strings.xml
+++ b/gpslogger/src/main/res/values-ru/strings.xml
@@ -242,7 +242,7 @@
   <string name="txt_annotation">Аннотации:</string>
   <string name="txt_time_isoformat">Время UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Провайдер:</string>
-  <string name="annotation_requires_logging">Требуется ведение журналов с аннотациями в GPX/KML/пользовательском URL</string>
+  <string name="annotation_requires_logging">Требуется ведение журналов с аннотациями в CSV/GPX/KML/пользовательском URL</string>
   <string name="gpslogger_folder_title">Сохранить в папке</string>
   <string name="gpslogger_folder_summary">Куда сохранять файлы журнала (по умолчанию в /sdcard/GPSLogger)</string>
   <string name="autoftp_directory">Папка</string>

--- a/gpslogger/src/main/res/values-sk/strings.xml
+++ b/gpslogger/src/main/res/values-sk/strings.xml
@@ -256,7 +256,7 @@ polia.
   <string name="txt_annotation">Poznámka:</string>
   <string name="txt_time_isoformat">Čas UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Poskytovateľ:</string>
-  <string name="annotation_requires_logging">Poznámky si vyžadujú zaznamenávanie do GPX/KML/na vlastnú adresu URL</string>
+  <string name="annotation_requires_logging">Poznámky si vyžadujú zaznamenávanie do CSV/GPX/KML/na vlastnú adresu URL</string>
   <string name="gpslogger_folder_title">Uložiť do priečinka</string>
   <string name="gpslogger_folder_summary">Kam chcete ukladať súbory so záznamom. Predvolene sa ukladajú do priečinka /sdcard/GPSLogger</string>
   <string name="autoftp_directory">Priečinok</string>

--- a/gpslogger/src/main/res/values-sv-rSE/strings.xml
+++ b/gpslogger/src/main/res/values-sv-rSE/strings.xml
@@ -233,7 +233,7 @@
   <string name="txt_annotation">Kommentar:</string>
   <string name="txt_time_isoformat">Tid UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Leverantör:</string>
-  <string name="annotation_requires_logging">Kommentarer kräver loggning till GPX/KML/Anpassad URL</string>
+  <string name="annotation_requires_logging">Kommentarer kräver loggning till CSV/GPX/KML/Anpassad URL</string>
   <string name="gpslogger_folder_title">Spara till mapp</string>
   <string name="gpslogger_folder_summary">Var loggfiler ska sparas, standard är /sdcard/GPSLogger</string>
   <string name="autoftp_directory">Mapp</string>

--- a/gpslogger/src/main/res/values-sv/strings.xml
+++ b/gpslogger/src/main/res/values-sv/strings.xml
@@ -217,7 +217,7 @@
   <string name="txt_annotation">Kommentar:</string>
   <string name="txt_time_isoformat">Tid UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Leverantör:</string>
-  <string name="annotation_requires_logging">Kommentarer kräver loggning till GPX/KML/Anpassad URL</string>
+  <string name="annotation_requires_logging">Kommentarer kräver loggning till CSV/GPX/KML/Anpassad URL</string>
   <string name="gpslogger_folder_title">Spara till mapp</string>
   <string name="gpslogger_folder_summary">Var loggfiler ska sparas, standard är /sdcard/GPSLogger</string>
   <string name="autoftp_directory">Katalog</string>

--- a/gpslogger/src/main/res/values-uk/strings.xml
+++ b/gpslogger/src/main/res/values-uk/strings.xml
@@ -231,7 +231,7 @@
   <string name="txt_annotation">Анотація:</string>
   <string name="txt_time_isoformat">Час UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Постачальник:</string>
-  <string name="annotation_requires_logging">Анотації потребують запису до GPX/KML/URL-адрес</string>
+  <string name="annotation_requires_logging">Анотації потребують запису до CSV/GPX/KML/URL-адрес</string>
   <string name="gpslogger_folder_title">Зберегти до папки</string>
   <string name="gpslogger_folder_summary">Де зберігати файли журналов, за замовчуванням /sdcard/GPSLogger</string>
   <string name="autoftp_directory">Папка</string>

--- a/gpslogger/src/main/res/values-vi/strings.xml
+++ b/gpslogger/src/main/res/values-vi/strings.xml
@@ -226,7 +226,7 @@
   <string name="txt_annotation">Chú thích:</string>
   <string name="txt_time_isoformat">Thời gian UTC (2011-12-25T15:27:33Z):</string>
   <string name="txt_provider">Nhà cung cấp:</string>
-  <string name="annotation_requires_logging">Chú thích đòi hỏi phải đăng nhập KML/GPX/URL</string>
+  <string name="annotation_requires_logging">Chú thích đòi hỏi phải đăng nhập CSV/KML/GPX/URL</string>
   <string name="gpslogger_folder_title">Lưu vào thư mục</string>
   <string name="gpslogger_folder_summary">Nơi để lưu các file log, mặc định là /sdcard/GPSLogger</string>
   <string name="autoftp_directory">Thư mục</string>

--- a/gpslogger/src/main/res/values-zh-rCN/strings.xml
+++ b/gpslogger/src/main/res/values-zh-rCN/strings.xml
@@ -235,7 +235,7 @@
   <string name="txt_annotation">注释︰</string>
   <string name="txt_time_isoformat">UTC 时间（2011-12-25T15:27:33Z）：</string>
   <string name="txt_provider">提供者：</string>
-  <string name="annotation_requires_logging">注释需要记录到 GPX/KML/自定义 URL</string>
+  <string name="annotation_requires_logging">注释需要记录到 CSV/GPX/KML/自定义 URL</string>
   <string name="gpslogger_folder_title">保存到文件夹</string>
   <string name="gpslogger_folder_summary">保存到哪个文件夹，缺省是 /sdcard/GPSLogger</string>
   <string name="autoftp_directory">文件夹</string>

--- a/gpslogger/src/main/res/values-zh-rTW/strings.xml
+++ b/gpslogger/src/main/res/values-zh-rTW/strings.xml
@@ -235,7 +235,7 @@
   <string name="txt_annotation">註釋︰</string>
   <string name="txt_time_isoformat">UTC 時間（2011-12-25T15:27:33Z）：</string>
   <string name="txt_provider">提供者：</string>
-  <string name="annotation_requires_logging">註釋需要記錄到 GPX/KML/自訂 URL</string>
+  <string name="annotation_requires_logging">註釋需要記錄到 CSV/GPX/KML/自訂 URL</string>
   <string name="gpslogger_folder_title">儲存到資料夾</string>
   <string name="gpslogger_folder_summary">儲存到哪個資料夾，缺省是 /sdcard/GPSLogger</string>
   <string name="autoftp_directory">資料夾</string>

--- a/gpslogger/src/main/res/values/strings.xml
+++ b/gpslogger/src/main/res/values/strings.xml
@@ -331,7 +331,7 @@
     <string name="txt_annotation">Annotation:</string>
     <string name="txt_time_isoformat">Time UTC (2011-12-25T15:27:33Z):</string>
     <string name="txt_provider">Provider:</string>
-    <string name="annotation_requires_logging">Annotations require logging to GPX/KML/Custom URL</string>
+    <string name="annotation_requires_logging">Annotations require logging to CSV/GPX/KML/Custom URL</string>
 
 
     <string name="gpslogger_folder_title">Save to folder</string>

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/csv/CSVFileLoggerTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/csv/CSVFileLoggerTest.java
@@ -165,6 +165,18 @@ public class CSVFileLoggerTest {
 
     }
 
+    @Test
+    public void getCsvLine_DescriptionContainsDoubleQuote_ReturnsCSVLineWithEscapedQuote(){
+        CSVFileLogger plain = new CSVFileLogger(null,47.238f);
+        Location loc = MockLocations.builder("MOCK", 12.222,14.151).build();
+
+        String actual = plain.getCsvLine("a..\"b\"..'c'", loc, "2011-09-17T18:45:33Z");
+        String expected = "2011-09-17T18:45:33Z,12.222000,14.151000,,,,,0,MOCK,,,,,,,,47.238,\"a..\"\"b\"\"..'c'\"\n";
+
+        assertThat("CSV With annotation", actual, is(expected));
+
+    }
+
 
 
 

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/csv/CSVFileLoggerTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/csv/CSVFileLoggerTest.java
@@ -1,8 +1,8 @@
-package com.mendhak.gpslogger_XYZ.loggers.csv;
+package com.mendhak.gpslogger.loggers.csv;
 
 import android.location.Location;
 import android.test.suitebuilder.annotation.SmallTest;
-import com.mendhak.gpslogger_XYZ.loggers.MockLocations;
+import com.mendhak.gpslogger.loggers.MockLocations;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/csv/CSVFileLoggerTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/csv/CSVFileLoggerTest.java
@@ -1,8 +1,8 @@
-package com.mendhak.gpslogger.loggers.csv;
+package com.mendhak.gpslogger_XYZ.loggers.csv;
 
 import android.location.Location;
 import android.test.suitebuilder.annotation.SmallTest;
-import com.mendhak.gpslogger.loggers.MockLocations;
+import com.mendhak.gpslogger_XYZ.loggers.MockLocations;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -19,7 +19,7 @@ public class CSVFileLoggerTest {
         Location loc = MockLocations.builder("MOCK", 12.193, 19.111).build();
 
         String actual = plain.getCsvLine(loc,"2011-09-17T18:45:33Z");
-        String expected = "2011-09-17T18:45:33Z,12.193000,19.111000,,,,,0,MOCK,,,,,,,,\n";
+        String expected = "2011-09-17T18:45:33Z,12.193000,19.111000,,,,,0,MOCK,,,,,,,,,\n";
         assertThat("Basic CSV line", actual, is(expected));
 
     }
@@ -30,7 +30,7 @@ public class CSVFileLoggerTest {
         Location loc = MockLocations.builder("MOCK", 12.193, 19.111).withAltitude(101).withAccuracy(41).withBearing(119).build();
 
         String actual = plain.getCsvLine(loc,"2011-09-17T18:45:33Z");
-        String expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,41.0,119.0,,0,MOCK,,,,,,,,\n";
+        String expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,41.0,119.0,,0,MOCK,,,,,,,,,\n";
         assertThat("CSV line with altitude, accuracy, bearing", actual, is(expected));
     }
 
@@ -40,7 +40,7 @@ public class CSVFileLoggerTest {
         Location loc = MockLocations.builder("BRAINS", 12.193, 19.111).withAltitude(101).withBearing(119).withSpeed(9).build();
 
         String actual = plain.getCsvLine(loc,"2011-09-17T18:45:33Z");
-        String expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,,119.0,9.0,0,BRAINS,,,,,,,,\n";
+        String expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,,119.0,9.0,0,BRAINS,,,,,,,,,\n";
         assertThat("CSV line with speed and provider", actual, is(expected));
     }
 
@@ -54,7 +54,7 @@ public class CSVFileLoggerTest {
                 .build();
 
         String actual = plain.getCsvLine(loc,"2011-09-17T18:45:33Z");
-        String expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,41.0,119.0,9.0,7,MOCK,,,,,,,,\n";
+        String expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,41.0,119.0,9.0,7,MOCK,,,,,,,,,\n";
         assertThat("CSV line with satellites or SATELLITES_FIX", actual, is(expected));
     }
 
@@ -67,7 +67,7 @@ public class CSVFileLoggerTest {
                 .build();
 
         String actual = plain.getCsvLine(loc,"2011-09-17T18:45:33Z");
-        String expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,41.0,119.0,9.0,7,MOCK,LOOKATTHISHDOP!,,,,,,,\n";
+        String expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,41.0,119.0,9.0,7,MOCK,LOOKATTHISHDOP!,,,,,,,,\n";
         assertThat("CSV line with HDOP", actual, is(expected));
 
         Location loc2 = MockLocations.builder("MOCK", 12.193, 19.111).withAltitude(101).withAccuracy(41).withBearing(119).withSpeed(9)
@@ -78,7 +78,7 @@ public class CSVFileLoggerTest {
                 .build();
 
         actual = plain.getCsvLine(loc2,"2011-09-17T18:45:33Z");
-        expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,41.0,119.0,9.0,7,MOCK,LOOKATTHISHDOP!,392.13,Papepeodpe,,,,,\n";
+        expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,41.0,119.0,9.0,7,MOCK,LOOKATTHISHDOP!,392.13,Papepeodpe,,,,,,\n";
         assertThat("CSV line with HDOP PDOP VDOP", actual, is(expected));
     }
 
@@ -94,7 +94,7 @@ public class CSVFileLoggerTest {
 
 
         String actual = plain.getCsvLine(loc,"2011-09-17T18:45:33Z");
-        String expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,41.0,119.0,9.0,7,MOCK,,,,tall,oldddd,777,,\n";
+        String expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,41.0,119.0,9.0,7,MOCK,,,,tall,oldddd,777,,,\n";
         assertThat("CSV line with geoid and dgps", actual, is(expected));
 
         Location loc2 = MockLocations.builder("MOCK", 12.193, 19.111).withAltitude(101).withAccuracy(41).withBearing(119).withSpeed(9)
@@ -108,7 +108,7 @@ public class CSVFileLoggerTest {
                 .build();
 
         actual = plain.getCsvLine(loc2,"2011-09-17T18:45:33Z");
-        expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,41.0,119.0,9.0,7,MOCK,LOOKATTHISHDOP!,392.13,Papepeodpe,tall,oldddd,777,,\n";
+        expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,41.0,119.0,9.0,7,MOCK,LOOKATTHISHDOP!,392.13,Papepeodpe,tall,oldddd,777,,,\n";
         assertThat("CSV line with all extras", actual, is(expected));
     }
 
@@ -118,7 +118,7 @@ public class CSVFileLoggerTest {
         Location loc = MockLocations.builder("MOCK", 12.222,14.151).putExtra("DETECTED_ACTIVITY","WALKING").build();
 
         String actual = plain.getCsvLine(loc,"2011-09-17T18:45:33Z");
-        String expected = "2011-09-17T18:45:33Z,12.222000,14.151000,,,,,0,MOCK,,,,,,,WALKING,\n";
+        String expected = "2011-09-17T18:45:33Z,12.222000,14.151000,,,,,0,MOCK,,,,,,,WALKING,,\n";
 
         assertThat("CSV with activity", actual, is(expected));
 
@@ -134,7 +134,7 @@ public class CSVFileLoggerTest {
                 .build();
 
         actual = plain.getCsvLine(loc2,"2011-09-17T18:45:33Z");
-        expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,41.0,119.0,9.0,7,MOCK,LOOKATTHISHDOP!,392.13,Papepeodpe,tall,oldddd,777,UNKNOWN,\n";
+        expected = "2011-09-17T18:45:33Z,12.193000,19.111000,101.0,41.0,119.0,9.0,7,MOCK,LOOKATTHISHDOP!,392.13,Papepeodpe,tall,oldddd,777,UNKNOWN,,\n";
         assertThat("CSV with activity", actual, is(expected));
 
     }
@@ -146,12 +146,24 @@ public class CSVFileLoggerTest {
         Location loc = MockLocations.builder("MOCK", 12.222,14.151).build();
 
         String actual = plain.getCsvLine(loc, "2011-09-17T18:45:33Z");
-        String expected = "2011-09-17T18:45:33Z,12.222000,14.151000,,,,,0,MOCK,,,,,,,,47.238\n";
+        String expected = "2011-09-17T18:45:33Z,12.222000,14.151000,,,,,0,MOCK,,,,,,,,47.238,\n";
 
         assertThat("CSV With battery", actual, is(expected));
 
     }
 
+
+    @Test
+    public void getCsvLine_LocationWithAnnotation_ReturnsCSVLine(){
+        CSVFileLogger plain = new CSVFileLogger(null,47.238f);
+        Location loc = MockLocations.builder("MOCK", 12.222,14.151).build();
+
+        String actual = plain.getCsvLine("はい", loc, "2011-09-17T18:45:33Z");
+        String expected = "2011-09-17T18:45:33Z,12.222000,14.151000,,,,,0,MOCK,,,,,,,,47.238,\"はい\"\n";
+
+        assertThat("CSV With annotation", actual, is(expected));
+
+    }
 
 
 


### PR DESCRIPTION
Added the ability to store annotations into the CSV file.

These can range from Emojis to Japanese characters. Generated files are parsesable by Python's csv.reader and annotations can be transformed to json strings without problems.

This will allow for server-side generation of kml files or webpages with embedded google maps including waypoints via post-processing.

> time,lat,lon,elevation,accuracy,bearing,speed,satellites,provider,hdop,vdop,pdop,geoidheight,ageofdgpsdata,dgpsid,activity,battery,annotation
2017-05-26T11:23:59.925Z,xx.xxx613,yy.y39825,,20.526,,,0,network,,,,,,,UNKNOWN,100.0,
2017-05-26T11:24:09.000Z,xx.xxx418,yy.y40032,476.0,11.0,127.7,0.7211103,6,gps,,,,,,,,100.0,
2017-05-26T11:24:55.000Z,xx.xxx511,yy.y39971,467.0,4.0,,0.0,9,gps,1.2,0.9,1.5,48.0,,,,100.0,"良 is ""ok"" ߘ"
2017-05-26T11:24:58.000Z,xx.xxx510,yy.y39971,467.0,4.0,,0.0,9,gps,1.0,0.9,1.3,48.0,,,,100.0,
2017-05-26T11:25:01.000Z,xx.xxx510,yy.y39971,467.0,3.0,,0.0,9,gps,1.0,0.9,1.3,48.0,,,UNKNOWN,100.0,
2017-05-26T11:25:04.000Z,xx.xxx510,yy.y39971,467.0,4.0,,0.0,9,gps,1.1,0.9,1.4,48.0,,,,100.0,
2017-05-26T11:25:07.000Z,xx.xxx510,yy.y39971,467.0,3.0,,0.0,9,gps,1.1,0.9,1.4,48.0,,,,100.0,
2017-05-26T11:25:09.000Z,xx.xxx510,yy.y39971,467.0,4.0,,0.0,8,gps,0.9,0.9,1.3,48.0,,,,100.0,"mark-1"
2017-05-26T11:25:12.000Z,xx.xxx509,yy.y39970,467.0,4.0,,0.0,8,gps,0.8,0.8,1.1,48.0,,,,100.0,
2017-05-26T11:25:15.000Z,xx.xxx508,yy.y39970,467.0,3.0,,0.0,8,gps,0.7,0.8,1.0,48.0,,,,100.0,"mark-2"
2017-05-26T11:25:18.000Z,xx.xxx508,yy.y39970,467.0,3.0,,0.0,8,gps,0.9,0.8,1.2,48.0,,,,100.0,