### PR TITLE
Update Gradle to 4.0 and Google Libs

### DIFF
--- a/gpslogger/build.gradle
+++ b/gpslogger/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.canelmas.let:let-plugin:0.1.10'
         classpath "com.mendhak.gradlecrowdin:crowdin-plugin:0.0.9"
         classpath 'org.jacoco:org.jacoco.core:0.7.4.201502262128'
@@ -124,7 +124,7 @@ android {
 
 dependencies {
 
-    compile 'com.android.support:support-v4:23.1.1'
+    compile 'com.android.support:support-v4:23.4.0'
     compile 'com.google.android.gms:play-services-base:8.4.0'
     compile 'com.google.android.gms:play-services-location:8.4.0'
     compile 'com.google.android.gms:play-services-wearable:8.4.0'
@@ -143,13 +143,13 @@ dependencies {
 
 
     //Android lollipop/material features including the Toolbar
-    compile "com.android.support:appcompat-v7:23.1.1"
+    compile "com.android.support:appcompat-v7:23.4.0"
 
     //Recycler view required by material dialog custom URL alert box
-    compile "com.android.support:recyclerview-v7:23.0.1"
+    compile "com.android.support:recyclerview-v7:23.4.0"
 
     //Cardviews
-    compile "com.android.support:cardview-v7:23.0.1"
+    compile "com.android.support:cardview-v7:23.4.0"
 
     //Material dialogs
     //Change to 0.8.5.7 when released

--- a/gpsloggerwear/build.gradle
+++ b/gpsloggerwear/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip


### PR DESCRIPTION
Gradle 4.0 has been released.
Also a few updates in the support libraries provided by Google have been released. 
This PR reflects that.