### PR TITLE
Always use meters or feet for altitude display, i.e.

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/Strings.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/Strings.java
@@ -296,19 +296,19 @@ public class Strings {
 
     }
 
-    public static String getDistanceDisplay(Context context, double meters, boolean imperial) {
+    public static String getDistanceDisplay(Context context, double meters, boolean imperial, boolean autoscale) {
         DecimalFormat df = new DecimalFormat("#.###");
         String result = df.format(meters) + context.getString(R.string.meters);
 
         if(imperial){
-            if (meters <= 804){
+            if (!autoscale || (meters <= 804)){
                 result = df.format(meters * 3.2808399) + context.getString(R.string.feet);
             }
             else {
                 result = df.format(meters/1609.344) + context.getString(R.string.miles);
             }
         }
-        else if(meters >= 1000){
+        else if(autoscale && (meters >= 1000)) {
             result = df.format(meters/1000) + context.getString(R.string.kilometers);
         }
 

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/display/GpsDetailedViewFragment.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/display/GpsDetailedViewFragment.java
@@ -177,7 +177,7 @@ public class GpsDetailedViewFragment extends GenericViewFragment {
             }
 
 
-            txtDistance.setText(Strings.getDistanceDisplay(getActivity(), preferenceHelper.getMinimumDistanceInterval(), preferenceHelper.shouldDisplayImperialUnits()));
+            txtDistance.setText(Strings.getDistanceDisplay(getActivity(), preferenceHelper.getMinimumDistanceInterval(), preferenceHelper.shouldDisplayImperialUnits(), true));
 
 
             if (preferenceHelper.isAutoSendEnabled() && preferenceHelper.getAutoSendInterval() > 0) {
@@ -350,7 +350,7 @@ public class GpsDetailedViewFragment extends GenericViewFragment {
         tvLongitude.setText(String.valueOf(Strings.getFormattedLongitude(locationInfo.getLongitude())));
 
         if (locationInfo.hasAltitude()) {
-            tvAltitude.setText(Strings.getDistanceDisplay(getActivity(), locationInfo.getAltitude(), preferenceHelper.shouldDisplayImperialUnits()));
+            tvAltitude.setText(Strings.getDistanceDisplay(getActivity(), locationInfo.getAltitude(), preferenceHelper.shouldDisplayImperialUnits(), false));
         } else {
             tvAltitude.setText(R.string.not_applicable);
         }
@@ -382,14 +382,14 @@ public class GpsDetailedViewFragment extends GenericViewFragment {
         if (locationInfo.hasAccuracy()) {
 
             float accuracy = locationInfo.getAccuracy();
-            txtAccuracy.setText(getString(R.string.accuracy_within, Strings.getDistanceDisplay(getActivity(), accuracy, preferenceHelper.shouldDisplayImperialUnits()), ""));
+            txtAccuracy.setText(getString(R.string.accuracy_within, Strings.getDistanceDisplay(getActivity(), accuracy, preferenceHelper.shouldDisplayImperialUnits(), true), ""));
 
         } else {
             txtAccuracy.setText(R.string.not_applicable);
         }
 
         double distanceValue = session.getTotalTravelled();
-        txtTravelled.setText(Strings.getDistanceDisplay(getActivity(), distanceValue, preferenceHelper.shouldDisplayImperialUnits()) + " (" + session.getNumLegs() + " points)");
+        txtTravelled.setText(Strings.getDistanceDisplay(getActivity(), distanceValue, preferenceHelper.shouldDisplayImperialUnits(), true) + " (" + session.getNumLegs() + " points)");
 
         long startTime = session.getStartTimeStamp();
         Date d = new Date(startTime);

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/display/GpsSimpleViewFragment.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/display/GpsSimpleViewFragment.java
@@ -335,7 +335,7 @@ public class GpsSimpleViewFragment extends GenericViewFragment implements View.O
 
             TextView txtAccuracy = (TextView) rootView.findViewById(R.id.simpleview_txtAccuracy);
             float accuracy = locationInfo.getAccuracy();
-            txtAccuracy.setText(Strings.getDistanceDisplay(getActivity(), accuracy, preferenceHelper.shouldDisplayImperialUnits()));
+            txtAccuracy.setText(Strings.getDistanceDisplay(getActivity(), accuracy, preferenceHelper.shouldDisplayImperialUnits(), true));
 
             if (accuracy > 500) {
                 setColor(imgAccuracy, IconColorIndicator.Warning);
@@ -355,7 +355,7 @@ public class GpsSimpleViewFragment extends GenericViewFragment implements View.O
             setColor(imgAltitude, IconColorIndicator.Good);
             TextView txtAltitude = (TextView) rootView.findViewById(R.id.simpleview_txtAltitude);
 
-            txtAltitude.setText(Strings.getDistanceDisplay(getActivity(), locationInfo.getAltitude(), preferenceHelper.shouldDisplayImperialUnits()));
+            txtAltitude.setText(Strings.getDistanceDisplay(getActivity(), locationInfo.getAltitude(), preferenceHelper.shouldDisplayImperialUnits(), false));
         }
 
         ImageView imgSpeed = (ImageView)rootView.findViewById(R.id.simpleview_imgSpeed);
@@ -392,7 +392,7 @@ public class GpsSimpleViewFragment extends GenericViewFragment implements View.O
         TextView txtPoints = (TextView) rootView.findViewById(R.id.simpleview_txtPoints);
         TextView txtTravelled = (TextView) rootView.findViewById(R.id.simpleview_txtDistance);
 
-        txtTravelled.setText(Strings.getDistanceDisplay(getActivity(), distanceValue, preferenceHelper.shouldDisplayImperialUnits()));
+        txtTravelled.setText(Strings.getDistanceDisplay(getActivity(), distanceValue, preferenceHelper.shouldDisplayImperialUnits(), true));
         txtPoints.setText(session.getNumLegs() + " " + getString(R.string.points));
 
         String providerName = locationInfo.getProvider();


### PR DESCRIPTION
do not allow altitude to scale to kilometers or miles.

This is a potential resolution for issue #576 .