### PR TITLE
Upgrades to work with Android Studio 3.0.1 and Gradle plugin 3.0.1 and Gradle 4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ android:
     components:
       - tools
       - platform-tools
-      - build-tools-25.0.3
+      - build-tools-26.0.2
       - android-23
       - extra-android-support
       - extra-android-m2repository

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This project uses certain Android libraries, you can install them using Google's
 
       echo y | $HOME/android-sdk/tools/bin/sdkmanager 'tools'
       echo y | $HOME/android-sdk/tools/bin/sdkmanager 'platform-tools'
-      echo y | $HOME/android-sdk/tools/bin/sdkmanager 'build-tools;25.0.3'
+      echo y | $HOME/android-sdk/tools/bin/sdkmanager 'build-tools;26.0.2'
       echo y | $HOME/android-sdk/tools/bin/sdkmanager 'platforms;android-23'
       echo y | $HOME/android-sdk/tools/bin/sdkmanager 'extras;google;m2repository'
       echo y | $HOME/android-sdk/tools/bin/sdkmanager 'extras;android;m2repository'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    repositories {
+        mavenCentral()
+        jcenter()
+        google()
+    }
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
+buildscript {
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.0.1'
+    }
+}
+
 project.ext.APP_ID = "com.mendhak.gpslogger"
 project.ext.APP_VERSION_CODE = 90
 project.ext.APP_VERSION_NAME = "90"

--- a/gpslogger/build.gradle
+++ b/gpslogger/build.gradle
@@ -5,9 +5,10 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.canelmas.let:let-plugin:0.1.10'
         classpath "com.mendhak.gradlecrowdin:crowdin-plugin:0.1.0"
         classpath 'org.jacoco:org.jacoco.core:0.7.4.201502262128'
@@ -43,7 +44,6 @@ repositories {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "25.0.3"
 
     defaultConfig {
         applicationId project.APP_ID
@@ -166,7 +166,7 @@ dependencies {
     }
 
     //Progress button
-    compile 'com.github.dmytrodanylyk.android-process-button:library:1.0.0'
+    compile 'com.github.dmytrodanylyk.android-process-button:library:1.0.4'
 
     //Android Priority Jobqueue
     compile ('com.birbit:android-priority-jobqueue:1.3.1'){

--- a/gpslogger/build.gradle
+++ b/gpslogger/build.gradle
@@ -352,7 +352,7 @@ task copyFinalAPK(group:'build') {
     def finalApkName = "gpslogger-"+android.defaultConfig.versionName+".apk"
 
     copy{
-        from "build/outputs/apk/gpslogger-release.apk"
+        from "build/outputs/apk/release/gpslogger-release.apk"
         into "./"
 
         // Use a closure to map the file name

--- a/gpsloggerwear/build.gradle
+++ b/gpsloggerwear/build.gradle
@@ -4,9 +4,10 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 
@@ -15,7 +16,6 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '25.0.3'
 
     defaultConfig {
         applicationId project.APP_ID

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
- Upgraded to Gradle plugin 3.0.1 and Gradle 4.1
- Upgraded com.github.dmytrodanylyk.android-process-button to 1.0.4 to work with new build tools
- Configured project to use default build tools version on Gradle plugin
- Included google repo