### PR TITLE
add gpx 1.1 file format support

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceHelper.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceHelper.java
@@ -533,6 +533,14 @@ public class PreferenceHelper {
         return prefs.getBoolean(PreferenceNames.LOG_TO_GPX, true);
     }
 
+    /**
+     * Whether to log to GPX in GPX 1.0 or 1.1 format
+     */
+    @ProfilePreference(name= PreferenceNames.LOG_AS_GPX_11)
+    public boolean shouldLogAsGpx11() {
+        return prefs.getBoolean(PreferenceNames.LOG_AS_GPX_11, false);
+    }
+
 
     /**
      * Whether to log to a CSV file

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceNames.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceNames.java
@@ -31,6 +31,7 @@ public  class PreferenceNames {
     public static final String START_LOGGING_ON_BOOTUP = "startonbootup";
     public static final String LOG_TO_KML = "log_kml";
     public static final String LOG_TO_GPX = "log_gpx";
+    public static final String LOG_AS_GPX_11 = "log_gpx_11";
     public static final String LOG_TO_CSV = "log_plain_text";
     public static final String LOG_TO_GEOJSON = "log_geojson";
     public static final String LOG_TO_NMEA = "log_nmea";

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/FileLoggerFactory.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/FileLoggerFactory.java
@@ -29,6 +29,7 @@ import com.mendhak.gpslogger.loggers.csv.CSVFileLogger;
 import com.mendhak.gpslogger.loggers.customurl.CustomUrlLogger;
 import com.mendhak.gpslogger.loggers.geojson.GeoJSONLogger;
 import com.mendhak.gpslogger.loggers.gpx.Gpx10FileLogger;
+import com.mendhak.gpslogger.loggers.gpx.Gpx11FileLogger;
 import com.mendhak.gpslogger.loggers.kml.Kml22FileLogger;
 import com.mendhak.gpslogger.loggers.opengts.OpenGTSLogger;
 import com.mendhak.gpslogger.loggers.wear.AndroidWearLogger;
@@ -57,7 +58,11 @@ public class FileLoggerFactory {
 
         if (preferenceHelper.shouldLogToGpx()) {
             File gpxFile = new File(gpxFolder.getPath(), Strings.getFormattedFileName() + ".gpx");
-            loggers.add(new Gpx10FileLogger(gpxFile, session.shouldAddNewTrackSegment()));
+            if(preferenceHelper.shouldLogAsGpx11()) {
+                loggers.add(new Gpx11FileLogger(gpxFile, session.shouldAddNewTrackSegment()));
+            } else {
+                loggers.add(new Gpx10FileLogger(gpxFile, session.shouldAddNewTrackSegment()));
+            }
         }
 
         if (preferenceHelper.shouldLogToKml()) {

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/gpx/Gpx10FileLogger.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/gpx/Gpx10FileLogger.java
@@ -51,7 +51,6 @@ public class Gpx10FileLogger implements FileLogger {
         this.addNewTrackSegment = addNewTrackSegment;
     }
 
-
     public void write(Location loc) throws Exception {
         long time = loc.getTime();
         if (time <= 0) {
@@ -59,14 +58,19 @@ public class Gpx10FileLogger implements FileLogger {
         }
         String dateTimeString = Strings.getIsoDateTime(new Date(time));
 
-        Gpx10WriteHandler writeHandler = new Gpx10WriteHandler(dateTimeString, gpxFile, loc, addNewTrackSegment);
+        Runnable writeHandler = getWriteHandler(dateTimeString, gpxFile, loc, addNewTrackSegment);
         EXECUTOR.execute(writeHandler);
     }
 
+    public Runnable getWriteHandler(String dateTimeString, File gpxFile, Location loc, boolean addNewTrackSegment)
+    {
+        return new Gpx10WriteHandler(dateTimeString, gpxFile, loc, addNewTrackSegment);
+    }
+
     public void annotate(String description, Location loc) throws Exception {
-        
+
         description = Strings.cleanDescriptionForXml(description);
-        
+
         long time = loc.getTime();
         if (time <= 0) {
             time = System.currentTimeMillis();
@@ -273,13 +277,7 @@ class Gpx10WriteHandler implements Runnable {
 
         track.append("<time>").append(dateTimeString).append("</time>");
 
-        if (loc.hasBearing()) {
-            track.append("<course>").append(String.valueOf(loc.getBearing())).append("</course>");
-        }
-
-        if (loc.hasSpeed()) {
-            track.append("<speed>").append(String.valueOf(loc.getSpeed())).append("</speed>");
-        }
+        appendCourseAndSpeed(track, loc);
 
         if (loc.getExtras() != null) {
             String geoidheight = loc.getExtras().getString(BundleConstants.GEOIDHEIGHT);
@@ -290,7 +288,6 @@ class Gpx10WriteHandler implements Runnable {
         }
 
         track.append("<src>").append(loc.getProvider()).append("</src>");
-
 
         if (loc.getExtras() != null) {
 
@@ -336,6 +333,14 @@ class Gpx10WriteHandler implements Runnable {
         return track.toString();
     }
 
+    public void appendCourseAndSpeed(StringBuilder track, Location loc)
+    {
+        if (loc.hasBearing()) {
+            track.append("<course>").append(String.valueOf(loc.getBearing())).append("</course>");
+        }
+
+        if (loc.hasSpeed()) {
+            track.append("<speed>").append(String.valueOf(loc.getSpeed())).append("</speed>");
+        }
+    }
 }
-
-

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/gpx/Gpx11FileLogger.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/gpx/Gpx11FileLogger.java
@@ -1,0 +1,47 @@
+package com.mendhak.gpslogger.loggers.gpx;
+
+import android.location.Location;
+
+import com.mendhak.gpslogger.BuildConfig;
+
+import java.io.File;
+
+/**
+ * Extension of the Gpx10FileLogger that produces overrides key methods to produce a GPX 1.1 compliant output file
+ */
+public class Gpx11FileLogger extends Gpx10FileLogger {
+    public Gpx11FileLogger(File gpxFile, boolean addNewTrackSegment) {
+        super(gpxFile, addNewTrackSegment);
+    }
+
+    public Runnable getWriteHandler(String dateTimeString, File gpxFile, Location loc, boolean addNewTrackSegment)
+    {
+        return new Gpx11WriteHandler(dateTimeString, gpxFile, loc, addNewTrackSegment);
+    }
+
+    class Gpx11WriteHandler extends Gpx10WriteHandler {
+        public Gpx11WriteHandler(String dateTimeString, File gpxFile, Location loc, boolean addNewTrackSegment) {
+            super(dateTimeString, gpxFile, loc, addNewTrackSegment);
+        }
+
+        String getBeginningXml(String dateTimeString){
+            // Use GPX 1.1 namespaces and put <time> inside a <metadata> element
+            StringBuilder initialXml = new StringBuilder();
+            initialXml.append("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>");
+            initialXml.append("<gpx version=\"1.1\" creator=\"GPSLogger " + BuildConfig.VERSION_CODE + " - http://gpslogger.mendhak.com/\" ");
+            initialXml.append("xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" ");
+            initialXml.append("xmlns=\"http://www.topografix.com/GPX/1/1\" ");
+            initialXml.append("xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 ");
+            initialXml.append("http://www.topografix.com/GPX/1/1/gpx.xsd\">");
+            initialXml.append("<metadata><time>").append(dateTimeString).append("</time></metadata>");
+            return initialXml.toString();
+        }
+
+        public void appendCourseAndSpeed(StringBuilder track, Location loc)
+        {
+            // no-op
+            // course and speed are not part of the GPX 1.1 specification
+            // We could put them in an extensions such if we really wanted.
+        }
+    }
+}

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/gpx/Gpx11FileLogger.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/gpx/Gpx11FileLogger.java
@@ -3,7 +3,6 @@ package com.mendhak.gpslogger.loggers.gpx;
 import android.location.Location;
 
 import com.mendhak.gpslogger.BuildConfig;
-
 import java.io.File;
 
 /**
@@ -19,29 +18,31 @@ public class Gpx11FileLogger extends Gpx10FileLogger {
         return new Gpx11WriteHandler(dateTimeString, gpxFile, loc, addNewTrackSegment);
     }
 
-    class Gpx11WriteHandler extends Gpx10WriteHandler {
-        public Gpx11WriteHandler(String dateTimeString, File gpxFile, Location loc, boolean addNewTrackSegment) {
-            super(dateTimeString, gpxFile, loc, addNewTrackSegment);
-        }
+}
 
-        String getBeginningXml(String dateTimeString){
-            // Use GPX 1.1 namespaces and put <time> inside a <metadata> element
-            StringBuilder initialXml = new StringBuilder();
-            initialXml.append("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>");
-            initialXml.append("<gpx version=\"1.1\" creator=\"GPSLogger " + BuildConfig.VERSION_CODE + " - http://gpslogger.mendhak.com/\" ");
-            initialXml.append("xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" ");
-            initialXml.append("xmlns=\"http://www.topografix.com/GPX/1/1\" ");
-            initialXml.append("xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 ");
-            initialXml.append("http://www.topografix.com/GPX/1/1/gpx.xsd\">");
-            initialXml.append("<metadata><time>").append(dateTimeString).append("</time></metadata>");
-            return initialXml.toString();
-        }
+class Gpx11WriteHandler extends Gpx10WriteHandler {
 
-        public void appendCourseAndSpeed(StringBuilder track, Location loc)
-        {
-            // no-op
-            // course and speed are not part of the GPX 1.1 specification
-            // We could put them in an extensions such if we really wanted.
-        }
+    public Gpx11WriteHandler(String dateTimeString, File gpxFile, Location loc, boolean addNewTrackSegment) {
+        super(dateTimeString, gpxFile, loc, addNewTrackSegment);
+    }
+
+    String getBeginningXml(String dateTimeString){
+        // Use GPX 1.1 namespaces and put <time> inside a <metadata> element
+        StringBuilder initialXml = new StringBuilder();
+        initialXml.append("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>");
+        initialXml.append("<gpx version=\"1.1\" creator=\"GPSLogger " + BuildConfig.VERSION_CODE + " - http://gpslogger.mendhak.com/\" ");
+        initialXml.append("xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" ");
+        initialXml.append("xmlns=\"http://www.topografix.com/GPX/1/1\" ");
+        initialXml.append("xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 ");
+        initialXml.append("http://www.topografix.com/GPX/1/1/gpx.xsd\">");
+        initialXml.append("<metadata><time>").append(dateTimeString).append("</time></metadata>");
+        return initialXml.toString();
+    }
+
+    public void appendCourseAndSpeed(StringBuilder track, Location loc)
+    {
+        // no-op
+        // course and speed are not part of the GPX 1.1 specification
+        // We could put them in an extensions such if we really wanted.
     }
 }

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/LoggingSettingsFragment.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/LoggingSettingsFragment.java
@@ -68,6 +68,12 @@ public class LoggingSettingsFragment extends PreferenceFragment
             gpsloggerFolder.setSummary(Html.fromHtml("<font color='red'>" + gpsLoggerFolderPath + "</font>"));
         }
 
+        CustomSwitchPreference logGpx = (CustomSwitchPreference)findPreference("log_gpx");
+        CustomSwitchPreference logGpx11 = (CustomSwitchPreference)findPreference("log_gpx_11");
+        logGpx.setOnPreferenceChangeListener(this);
+        logGpx11.setEnabled(logGpx.isChecked());
+
+
         /**
          * Logging Details - New file creation
          */
@@ -175,6 +181,14 @@ public class LoggingSettingsFragment extends PreferenceFragment
 
     @Override
     public boolean onPreferenceChange(final Preference preference, Object newValue) {
+
+
+        if(preference.getKey().equalsIgnoreCase("log_gpx")){
+            CustomSwitchPreference logGpx11 = (CustomSwitchPreference)findPreference("log_gpx_11");
+            logGpx11.setEnabled((Boolean)newValue);
+            return true;
+        }
+
 
         if (preference.getKey().equalsIgnoreCase("log_opengts")) {
 

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/LoggingSettingsFragment.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/LoggingSettingsFragment.java
@@ -70,6 +70,10 @@ public class LoggingSettingsFragment extends PreferenceFragment
 
         CustomSwitchPreference logGpx = (CustomSwitchPreference)findPreference("log_gpx");
         CustomSwitchPreference logGpx11 = (CustomSwitchPreference)findPreference("log_gpx_11");
+        logGpx11.setTitle("      " + logGpx11.getTitle());
+        logGpx11.setSummary("      " + logGpx11.getSummary());
+
+
         logGpx.setOnPreferenceChangeListener(this);
         logGpx11.setEnabled(logGpx.isChecked());
 

--- a/gpslogger/src/main/res/values/strings.xml
+++ b/gpslogger/src/main/res/values/strings.xml
@@ -120,6 +120,8 @@
     <string name="pref_logging_title">Logging details</string>
     <string name="log_gpx_title">Log to GPX</string>
     <string name="log_gpx_summary">Logs locations to a GPX v1.0 file</string>
+    <string name="log_gpx_11_title">Use GPX 1.1</string>
+    <string name="log_gpx_11_summary">Uses GPX 1.1 file format instead of GPX 1.0</string>
     <string name="log_kml_title">Log to KML</string>
     <string name="log_kml_summary">Logs locations to a KML v2.2 file</string>
     <string name="log_plain_text_title">Log to CSV</string>

--- a/gpslogger/src/main/res/xml/pref_logging.xml
+++ b/gpslogger/src/main/res/xml/pref_logging.xml
@@ -12,6 +12,12 @@
             android:defaultValue="true"/>
 
         <com.mendhak.gpslogger.ui.components.CustomSwitchPreference
+            android:key="log_gpx_11"
+            android:title="@string/log_gpx_11_title"
+            android:summary="@string/log_gpx_11_summary"
+            android:defaultValue="false"/>
+
+        <com.mendhak.gpslogger.ui.components.CustomSwitchPreference
             android:key="log_kml"
             android:summary="@string/log_kml_summary"
             android:title="@string/log_kml_title"/>

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/gpx/Gpx10AnnotateHandlerTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/gpx/Gpx10AnnotateHandlerTest.java
@@ -2,10 +2,15 @@ package com.mendhak.gpslogger.loggers.gpx;
 
 import android.location.Location;
 import android.test.suitebuilder.annotation.SmallTest;
+
+import com.mendhak.gpslogger.BuildConfig;
+import com.mendhak.gpslogger.common.Strings;
 import com.mendhak.gpslogger.loggers.MockLocations;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -17,7 +22,7 @@ public class Gpx10AnnotateHandlerTest {
 
     @Test
     public void GetWaypointXml_BasicLocation_BasicWptNodeReturned(){
-        Gpx10AnnotateHandler annotateHandler = new Gpx10AnnotateHandler(null, null, null, null);
+        Gpx10AnnotateHandler annotateHandler = new Gpx10AnnotateHandler(null, null, null, null,0);
 
 
         Location loc = MockLocations.builder("MOCK", 12.193, 19.111).build();
@@ -34,7 +39,7 @@ public class Gpx10AnnotateHandlerTest {
 
     @Test
     public void GetWaypointXml_LocationWithAltitude_WptNodeWithElevationReturned(){
-        Gpx10AnnotateHandler annotateHandler = new Gpx10AnnotateHandler(null, null, null, null);
+        Gpx10AnnotateHandler annotateHandler = new Gpx10AnnotateHandler(null, null, null, null,0);
 
         Location loc = MockLocations.builder("MOCK", 12.193, 19.111).withAltitude(9001d).build();
 
@@ -42,6 +47,22 @@ public class Gpx10AnnotateHandlerTest {
         String expected = "\n<wpt lat=\"12.193\" lon=\"19.111\"><ele>9001.0</ele><time>2011-09-17T18:45:33Z</time><name>This is the annotation</name><src>MOCK</src></wpt>\n";
 
         assertThat("Basic waypoint XML", actual, is(expected));
+    }
+
+    @Test
+    public void InitialXmlLength_Verify(){
+        Gpx10WriteHandler writeHandler = new Gpx10WriteHandler(null, null, null, true);
+        Gpx10AnnotateHandler annotateHandler = new Gpx10AnnotateHandler(null, null,
+                null, null,
+                writeHandler.getBeginningXml(Strings.getIsoDateTime(new Date(1483054318298l))).length());
+
+
+        String actual = writeHandler.getBeginningXml(Strings.getIsoDateTime(new Date(1483054318298l)));
+        String expected =   "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><gpx version=\"1.0\" creator=\"GPSLogger "+ BuildConfig.VERSION_CODE  +" - http://gpslogger.mendhak.com/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.topografix.com/GPX/1/0\" xsi:schemaLocation=\"http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd\"><time>2016-12-29T23:31:58.298Z</time>";
+
+        assertThat("InitialXml matches", actual, is(expected));
+        assertThat("Initial XML Length is correct", actual.length(), is(343));
+        assertThat("Initial XML length constant is set for others to use", actual.length(), is(annotateHandler.annotateOffset));
     }
 
 }

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/gpx/Gpx10WriteHandlerTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/gpx/Gpx10WriteHandlerTest.java
@@ -175,18 +175,7 @@ public class Gpx10WriteHandlerTest {
         assertThat("Trackpoint XML with a geoid height", actual, is(expected));
     }
 
-    @Test
-    public void GetBeginningXml_Verify(){
-        Gpx10WriteHandler writeHandler = new Gpx10WriteHandler(null, null, null, true);
 
-
-        String actual = writeHandler.getBeginningXml(Strings.getIsoDateTime(new Date(1483054318298l)));
-        String expected =   "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><gpx version=\"1.0\" creator=\"GPSLogger "+ BuildConfig.VERSION_CODE  +" - http://gpslogger.mendhak.com/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.topografix.com/GPX/1/0\" xsi:schemaLocation=\"http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd\"><time>2016-12-29T23:31:58.298Z</time>";
-
-        assertThat("InitialXml matches", actual, is(expected));
-        assertThat("Initial XML Length is correct", actual.length(), is(343));
-        assertThat("Initial XML length constant is set for others to use", actual.length(), is(Gpx10WriteHandler.INITIAL_XML_LENGTH));
-    }
 
     @Test
     public void GetEndXml_Verify(){

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/gpx/Gpx11WriteHandlerTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/gpx/Gpx11WriteHandlerTest.java
@@ -1,0 +1,34 @@
+package com.mendhak.gpslogger.loggers.gpx;
+
+import android.test.suitebuilder.annotation.SmallTest;
+import com.mendhak.gpslogger.BuildConfig;
+import com.mendhak.gpslogger.common.Strings;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Date;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@SmallTest
+@RunWith(MockitoJUnitRunner.class)
+public class Gpx11WriteHandlerTest {
+    @Test
+    public void InitialXmlLength_Verify(){
+        Gpx11WriteHandler writeHandler = new Gpx11WriteHandler(null, null, null, true);
+        Gpx10AnnotateHandler annotateHandler = new Gpx10AnnotateHandler(null, null,
+                null, null,
+                writeHandler.getBeginningXml(Strings.getIsoDateTime(new Date(1483054318298l))).length());
+
+
+        String actual = writeHandler.getBeginningXml(Strings.getIsoDateTime(new Date(1483054318298l)));
+        String expected =   "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><gpx version=\"1.1\" creator=\"GPSLogger "+ BuildConfig.VERSION_CODE  +" - http://gpslogger.mendhak.com/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.topografix.com/GPX/1/1\" xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd\"><metadata><time>2016-12-29T23:31:58.298Z</time></metadata>";
+
+        assertThat("InitialXml matches", actual, is(expected));
+        assertThat("Initial XML Length is correct", actual.length(), is(364));
+        assertThat("Initial XML length constant is set for others to use", actual.length(), is(annotateHandler.annotateOffset));
+    }
+
+}


### PR DESCRIPTION
Some websites (in particular Garmin connect) don't accept GPX 1.0 files any more.
I've extended the logger infrastructure to have a GPX11 logger that produces a GPX 1.1 compliant log file.
I've introduced a matching Preference so that if you choose to have GPX recording, you can choose between 1.0 and 1.1 (1.0 contains speed and course information which was dropped from the 1.1 spec it seems).

I've done some testing by recording on a physical device and then validating the GPX file according to the specification - seems to be fine.
I've also uploaded a recorded file to garmin and it works correctly.