### PR TITLE
Milestone 121

### DIFF
--- a/gpslogger/build.gradle
+++ b/gpslogger/build.gradle
@@ -44,8 +44,8 @@ android {
         minSdkVersion 16
         targetSdkVersion 30
 
-        versionCode 120
-        versionName "120"
+        versionCode 121
+        versionName "121-rc1"
     }
 
     buildTypes {

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/GpsLoggingService.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/GpsLoggingService.java
@@ -211,6 +211,7 @@ public class GpsLoggingService extends Service  {
                 if(bundle.getString(IntentConstants.SWITCH_PROFILE) != null){
                     LOG.info("Intent received - switch profile: " + bundle.getString(IntentConstants.SWITCH_PROFILE));
                     EventBus.getDefault().post(new ProfileEvents.SwitchToProfile(bundle.getString(IntentConstants.SWITCH_PROFILE)));
+                    needToStartGpsManager = session.isStarted();
                 }
 
                 if (bundle.get(IntentConstants.PREFER_CELLTOWER) != null) {

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/GpsMainActivity.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/GpsMainActivity.java
@@ -693,6 +693,7 @@ public class GpsMainActivity extends AppCompatActivity
                 .withSavedInstance(savedInstanceState)
                 .withProfileImagesVisible(false)
                 .withHeaderBackground(new ColorDrawable(ContextCompat.getColor(getApplicationContext(), R.color.accentColor)))
+                .withCloseDrawerOnProfileListClick(false)
                 .withOnAccountHeaderListener(new AccountHeader.OnAccountHeaderListener() {
 
                     @Override

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/GpsMainActivity.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/GpsMainActivity.java
@@ -675,6 +675,9 @@ public class GpsMainActivity extends AppCompatActivity
 
             public void onDrawerClosed(View view) {
                 invalidateOptionsMenu();
+                if(drawerHeader.isSelectionListShown()){
+                    drawerHeader.toggleSelectionList(getApplicationContext());
+                }
             }
 
             public void onDrawerOpened(View drawerView) {

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/Strings.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/Strings.java
@@ -25,6 +25,8 @@ import android.os.Build;
 import com.mendhak.gpslogger.BuildConfig;
 import com.mendhak.gpslogger.R;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
@@ -509,6 +511,14 @@ public class Strings {
             default:
                 return getDecimalDegrees(decimaldegrees);
 
+        }
+    }
+
+    public static String getUrlEncodedString(String message){
+        try {
+            return URLEncoder.encode(message, "UTF-8").replace("%3A", ":");
+        } catch (Exception e) {
+            return message;
         }
     }
 

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManager.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManager.java
@@ -26,7 +26,10 @@ import java.io.Reader;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public class CustomUrlManager extends FileSender {
 
@@ -195,39 +198,51 @@ public class CustomUrlManager extends FileSender {
 
         String logUrl = customLoggingUrl;
 
-        logUrl = logUrl.replaceAll("(?i)%lat", String.valueOf(sLoc.getLatitude()));
-        logUrl = logUrl.replaceAll("(?i)%lon", String.valueOf(sLoc.getLongitude()));
-        logUrl = logUrl.replaceAll("(?i)%sat", String.valueOf(sLoc.getSatelliteCount()));
-        logUrl = logUrl.replaceAll("(?i)%desc", String.valueOf(URLEncoder.encode(Strings.htmlDecode(description), "UTF-8")));
-        logUrl = logUrl.replaceAll("(?i)%alt", String.valueOf(sLoc.getAltitude()));
-        logUrl = logUrl.replaceAll("(?i)%acc", String.valueOf(sLoc.getAccuracy()));
-        logUrl = logUrl.replaceAll("(?i)%dir", String.valueOf(sLoc.getBearing()));
-        logUrl = logUrl.replaceAll("(?i)%prov", String.valueOf(sLoc.getProvider()));
-        logUrl = logUrl.replaceAll("(?i)%spd", String.valueOf(sLoc.getSpeed()));
-        logUrl = logUrl.replaceAll("(?i)%timestamp", String.valueOf(sLoc.getTime()/1000));
+        Map<String, String> replacements = new LinkedHashMap<String, String>();
+        replacements.put("lat", String.valueOf(sLoc.getLatitude()));
+        replacements.put("lon", String.valueOf(sLoc.getLongitude()));
+        replacements.put("sat", String.valueOf(sLoc.getSatelliteCount()));
+        replacements.put("desc", String.valueOf(URLEncoder.encode(Strings.htmlDecode(description), "UTF-8")));
+        replacements.put("alt", String.valueOf(sLoc.getAltitude()));
+        replacements.put("acc", String.valueOf(sLoc.getAccuracy()));
+        replacements.put("dir", String.valueOf(sLoc.getBearing()));
+        replacements.put("prov", String.valueOf(sLoc.getProvider()));
+        replacements.put("spd", String.valueOf(sLoc.getSpeed()));
+        replacements.put("timestamp", String.valueOf(sLoc.getTime()/1000));
 
         if(!Strings.isNullOrEmpty(sLoc.getTimeWithOffset())){
-            logUrl = logUrl.replaceAll("(?i)%timeoffset", sLoc.getTimeWithOffset());
+            replacements.put("timeoffset", sLoc.getTimeWithOffset());
         }
         else {
-            logUrl = logUrl.replaceAll("(?i)%timeoffset", Strings.getIsoDateTimeWithOffset(new Date(sLoc.getTime())));
+            replacements.put("timeoffset", Strings.getIsoDateTimeWithOffset(new Date(sLoc.getTime())));
         }
 
+        replacements.put("time", String.valueOf(Strings.getIsoDateTime(new Date(sLoc.getTime()))));
+        replacements.put("starttimestamp", String.valueOf(sessionStartTimeStamp/1000));
+        replacements.put("date", String.valueOf(Strings.getIsoCalendarDate(new Date(sLoc.getTime()))));
+        replacements.put("batt", String.valueOf(batteryLevel));
+        replacements.put("ischarging", String.valueOf(isCharging));
+        replacements.put("aid", String.valueOf(androidId));
+        replacements.put("ser", String.valueOf(buildSerial));
+        replacements.put("act", ""); //Activity detection was removed, but keeping this here for backward compatibility.
+        replacements.put("filename", fileName);
+        replacements.put("profile",URLEncoder.encode(profileName, "UTF-8"));
+        replacements.put("hdop", sLoc.getHDOP());
+        replacements.put("vdop", sLoc.getVDOP());
+        replacements.put("pdop", sLoc.getPDOP());
+        replacements.put("dist", String.valueOf((int)distance));
 
-        logUrl = logUrl.replaceAll("(?i)%time", String.valueOf(Strings.getIsoDateTime(new Date(sLoc.getTime()))));
-        logUrl = logUrl.replaceAll("(?i)%date", String.valueOf(Strings.getIsoCalendarDate(new Date(sLoc.getTime()))));
-        logUrl = logUrl.replaceAll("(?i)%starttimestamp", String.valueOf(sessionStartTimeStamp/1000));
-        logUrl = logUrl.replaceAll("(?i)%batt", String.valueOf(batteryLevel));
-        logUrl = logUrl.replaceAll("(?i)%ischarging", String.valueOf(isCharging));
-        logUrl = logUrl.replaceAll("(?i)%aid", String.valueOf(androidId));
-        logUrl = logUrl.replaceAll("(?i)%ser", String.valueOf(buildSerial));
-        logUrl = logUrl.replaceAll("(?i)%act", ""); //Activity detection was removed, but keeping this here for backward compatibility.
-        logUrl = logUrl.replaceAll("(?i)%filename", fileName);
-        logUrl = logUrl.replaceAll("(?i)%profile",URLEncoder.encode(profileName, "UTF-8"));
-        logUrl = logUrl.replaceAll("(?i)%hdop", sLoc.getHDOP());
-        logUrl = logUrl.replaceAll("(?i)%vdop", sLoc.getVDOP());
-        logUrl = logUrl.replaceAll("(?i)%pdop", sLoc.getPDOP());
-        logUrl = logUrl.replaceAll("(?i)%dist", String.valueOf((int)distance));
+        if(customLoggingUrl.toUpperCase().contains("%ALL")){
+            StringBuilder sbAll = new StringBuilder();
+            for (String q : replacements.keySet()){
+                sbAll.append(q + "=%" + q + "&");
+            }
+            logUrl = logUrl.replaceAll("(?i)%ALL", sbAll.toString());
+        }
+
+        for (String m : replacements.keySet()) {
+            logUrl = logUrl.replaceAll("(?i)%"+m, replacements.get(m));
+        }
 
         return logUrl;
     }

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManager.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManager.java
@@ -23,7 +23,6 @@ import org.slf4j.Logger;
 import java.io.File;
 import java.io.FileReader;
 import java.io.Reader;
-import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -202,7 +201,7 @@ public class CustomUrlManager extends FileSender {
         replacements.put("lat", String.valueOf(sLoc.getLatitude()));
         replacements.put("lon", String.valueOf(sLoc.getLongitude()));
         replacements.put("sat", String.valueOf(sLoc.getSatelliteCount()));
-        replacements.put("desc", String.valueOf(URLEncoder.encode(Strings.htmlDecode(description), "UTF-8")));
+        replacements.put("desc", String.valueOf(Strings.getUrlEncodedString(Strings.htmlDecode(description))));
         replacements.put("alt", String.valueOf(sLoc.getAltitude()));
         replacements.put("acc", String.valueOf(sLoc.getAccuracy()));
         replacements.put("dir", String.valueOf(sLoc.getBearing()));
@@ -211,13 +210,13 @@ public class CustomUrlManager extends FileSender {
         replacements.put("timestamp", String.valueOf(sLoc.getTime()/1000));
 
         if(!Strings.isNullOrEmpty(sLoc.getTimeWithOffset())){
-            replacements.put("timeoffset", sLoc.getTimeWithOffset());
+            replacements.put("timeoffset", Strings.getUrlEncodedString(sLoc.getTimeWithOffset()));
         }
         else {
-            replacements.put("timeoffset", Strings.getIsoDateTimeWithOffset(new Date(sLoc.getTime())));
+            replacements.put("timeoffset", Strings.getUrlEncodedString(Strings.getIsoDateTimeWithOffset(new Date(sLoc.getTime()))));
         }
 
-        replacements.put("time", String.valueOf(Strings.getIsoDateTime(new Date(sLoc.getTime()))));
+        replacements.put("time", String.valueOf(Strings.getUrlEncodedString(Strings.getIsoDateTime(new Date(sLoc.getTime())))));
         replacements.put("starttimestamp", String.valueOf(sessionStartTimeStamp/1000));
         replacements.put("date", String.valueOf(Strings.getIsoCalendarDate(new Date(sLoc.getTime()))));
         replacements.put("batt", String.valueOf(batteryLevel));
@@ -226,7 +225,7 @@ public class CustomUrlManager extends FileSender {
         replacements.put("ser", String.valueOf(buildSerial));
         replacements.put("act", ""); //Activity detection was removed, but keeping this here for backward compatibility.
         replacements.put("filename", fileName);
-        replacements.put("profile",URLEncoder.encode(profileName, "UTF-8"));
+        replacements.put("profile", Strings.getUrlEncodedString(profileName));
         replacements.put("hdop", sLoc.getHDOP());
         replacements.put("vdop", sLoc.getVDOP());
         replacements.put("pdop", sLoc.getPDOP());

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/CustomUrlFragment.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/CustomUrlFragment.java
@@ -144,7 +144,9 @@ public class CustomUrlFragment extends PreferenceFragmentCompat implements
                     getString(R.string.txt_time_with_offset_isoformat),
                     getString(R.string.txt_date_isoformat),
                     getString(R.string.txt_starttimestamp_epoch),
-                    getString(R.string.txt_battery), getString(R.string.txt_battery_charging), "Android ID ", "Serial ", getString(R.string.summary_current_filename), "Profile:", "HDOP:", "VDOP:", "PDOP:", getString(R.string.txt_travel_distance), "All parameters:");
+                    getString(R.string.txt_battery), getString(R.string.txt_battery_charging), "Android ID ", "Serial ",
+                    getString(R.string.summary_current_filename), "Profile:", "HDOP:", "VDOP:", "PDOP:",
+                    getString(R.string.txt_travel_distance), getString(R.string.customurl_all_parameters));
             Dialogs.alert(getString(R.string.parameters), legend1, getActivity());
             return true;
         }

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/CustomUrlFragment.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/CustomUrlFragment.java
@@ -132,7 +132,8 @@ public class CustomUrlFragment extends PreferenceFragmentCompat implements
                             "{21} <font color=''#{0}'' face=''monospace''>%HDOP</font><br />" +
                             "{22} <font color=''#{0}'' face=''monospace''>%VDOP</font><br />" +
                             "{23} <font color=''#{0}'' face=''monospace''>%PDOP</font><br />" +
-                            "{24} <font color=''#{0}'' face=''monospace''>%DIST</font>";
+                            "{24} <font color=''#{0}'' face=''monospace''>%DIST</font><br />" +
+                            "{25} <font color=''#{0}'' face=''monospace''>%ALL</font>";
             String legend1 = MessageFormat.format(legendFormat,
                     codeGreen,
                     getString(R.string.txt_latitude), getString(R.string.txt_longitude), getString(R.string.txt_annotation),
@@ -143,7 +144,7 @@ public class CustomUrlFragment extends PreferenceFragmentCompat implements
                     getString(R.string.txt_time_with_offset_isoformat),
                     getString(R.string.txt_date_isoformat),
                     getString(R.string.txt_starttimestamp_epoch),
-                    getString(R.string.txt_battery), getString(R.string.txt_battery_charging), "Android ID ", "Serial ", getString(R.string.summary_current_filename), "Profile:", "HDOP:", "VDOP:", "PDOP:", getString(R.string.txt_travel_distance));
+                    getString(R.string.txt_battery), getString(R.string.txt_battery_charging), "Android ID ", "Serial ", getString(R.string.summary_current_filename), "Profile:", "HDOP:", "VDOP:", "PDOP:", getString(R.string.txt_travel_distance), "All parameters:");
             Dialogs.alert(getString(R.string.parameters), legend1, getActivity());
             return true;
         }

--- a/gpslogger/src/main/res/values/strings.xml
+++ b/gpslogger/src/main/res/values/strings.xml
@@ -476,6 +476,7 @@
     <string name="file_logging_log_time_with_offset_summary">Where possible, write the ISO8601 time with timezone offset instead of UTC.</string>
     <string name="logging_advanced_delete_files">Delete selected files</string>
     <string name="logging_advanced_delete_files_summary">Long press to select multiple files.</string>
+    <string name="customurl_all_parameters">All parameters:</string>
 
 
 </resources>

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/common/StringsTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/common/StringsTest.java
@@ -524,4 +524,39 @@ public class StringsTest {
 
     }
 
+    @Test
+    public void getUrlEncodedString_stringWithSpace_shouldBeReplacedWithPlus(){
+        String expected = "a+b+c%2C+x+y+z";
+        String actual = Strings.getUrlEncodedString("a b c, x y z");
+
+        assertThat("Spaces should be replaced by plus", actual, is(expected));
+    }
+
+    @Test
+    public void getUrlEncodedString_stringWithPlus_shouldBeReplacedWith2B(){
+        String expected = "a%2Bb%2Bc";
+        String actual = Strings.getUrlEncodedString("a+b+c");
+
+        assertThat("Plus should be replaced by 2B", actual, is(expected));
+    }
+
+    @Test
+    public void getUrlEncodedString_stringWithColon_shouldNotBeReplaced(){
+        String expected = "a:b:c";
+        String actual = Strings.getUrlEncodedString("a:b:c");
+
+        assertThat("Colon should not be replaced, it just looks nicer!", actual, is(expected));
+    }
+
+    @Test
+    public void getUrlEncodedString_stringWithTimestamp_shouldReplaceButNotColons(){
+        String expected = "2022-04-22T03:59:17%2B01:00";
+        String actual = Strings.getUrlEncodedString("2022-04-22T03:59:17+01:00");
+
+        assertThat("Timestamp should be encoded, except for the colons", actual, is(expected));
+    }
+
+
+
+
 }

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/gpx/Gpx11WriteHandlerTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/loggers/gpx/Gpx11WriteHandlerTest.java
@@ -24,7 +24,7 @@ public class Gpx11WriteHandlerTest {
 
 
         String actual = writeHandler.getBeginningXml(Strings.getIsoDateTime(new Date(1483054318298l)));
-        String expected =   "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><gpx version=\"1.1\" creator=\"GPSLogger 120 - http://gpslogger.mendhak.com/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.topografix.com/GPX/1/1\" xmlns:gpxtpx=\"http://www.garmin.com/xmlschemas/TrackPointExtension/v2\" xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v2 https://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd \"><metadata><time>2016-12-29T23:31:58.298Z</time></metadata>";
+        String expected =   "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><gpx version=\"1.1\" creator=\"GPSLogger 121 - http://gpslogger.mendhak.com/\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"http://www.topografix.com/GPX/1/1\" xmlns:gpxtpx=\"http://www.garmin.com/xmlschemas/TrackPointExtension/v2\" xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v2 https://www8.garmin.com/xmlschemas/TrackPointExtensionv2.xsd \"><metadata><time>2016-12-29T23:31:58.298Z</time></metadata>";
 
 
         assertThat("InitialXml matches", actual, is(expected));

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManagerTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManagerTest.java
@@ -104,7 +104,7 @@ public class CustomUrlManagerTest {
         Location loc = MockLocations.builder("MOCK", 12.193, 19.456)
                 .withTime(1457205869949l).build();
         CustomUrlManager manager = new CustomUrlManager(null);
-        String expected = "http://192.168.1.65:8000/test?lat=12.193&lon=19.456&timeoff=2016-03-05T21:24:29.949+02:00";
+        String expected = "http://192.168.1.65:8000/test?lat=12.193&lon=19.456&timeoff=2016-03-05T21:24:29.949%2B02:00";
         String urlTemplate = "http://192.168.1.65:8000/test?lat=%LAT&lon=%LON&timeoff=%TIMEOFFSET";
 
         assertThat("TIMEOFFSET parameter is substituted with ISO Date Format, with time offset",
@@ -125,7 +125,7 @@ public class CustomUrlManagerTest {
                 .build();
 
         CustomUrlManager manager = new CustomUrlManager(null);
-        String expected = "http://192.168.1.65:8000/test?lat=12.193&lon=19.456&timeoff=2016-05-02T20:14:19.349+03:00";
+        String expected = "http://192.168.1.65:8000/test?lat=12.193&lon=19.456&timeoff=2016-05-02T20:14:19.349%2B03:00";
         String urlTemplate = "http://192.168.1.65:8000/test?lat=%LAT&lon=%LON&timeoff=%TIMEOFFSET";
 
         assertThat("TIMEOFFSET parameter is substituted with value from bundle",
@@ -290,7 +290,7 @@ public class CustomUrlManagerTest {
         CustomUrlManager manager = new CustomUrlManager(null);
         String expected = "http://192.168.1.65:8000/test?lat=12.193&lon=19.456&sat=0&desc=&alt=0.0" +
                 "&acc=0.0&dir=0.0&prov=MOCK&spd=0.0&timestamp=1457205869" +
-                "&timeoffset=2016-03-05T21:24:29.949+02:00&time=2016-03-05T19:24:29.949Z" +
+                "&timeoffset=2016-03-05T21:24:29.949%2B02:00&time=2016-03-05T19:24:29.949Z" +
                 "&starttimestamp=1495884681&date=2016-03-05&batt=0.0&ischarging=false&aid=&ser=" +
                 "&act=&filename=20170527abc&profile=Default+Profile&hdop=&vdop=19&pdop=&dist=0&";
         String urlTemplate = "http://192.168.1.65:8000/test?%ALL";
@@ -307,7 +307,7 @@ public class CustomUrlManagerTest {
                 .putExtra(BundleConstants.VDOP, "19").withTime(1457205869949l).build();
         CustomUrlManager manager = new CustomUrlManager(null);
         String expected = "lat=12.193&lon=19.456&sat=0&desc=&alt=0.0&acc=0.0&dir=0.0&prov=MOCK" +
-                "&spd=0.0&timestamp=1457205869&timeoffset=2016-03-05T21:24:29.949+02:00" +
+                "&spd=0.0&timestamp=1457205869&timeoffset=2016-03-05T21:24:29.949%2B02:00" +
                 "&time=2016-03-05T19:24:29.949Z&starttimestamp=1495884681&date=2016-03-05" +
                 "&batt=0.0&ischarging=false&aid=&ser=&act=&filename=20170527abc" +
                 "&profile=Default+Profile&hdop=&vdop=19&pdop=&dist=0&";

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManagerTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManagerTest.java
@@ -283,4 +283,40 @@ public class CustomUrlManagerTest {
                 is(expected));
     }
 
+    @Test
+    public void getFormattedUrl_WhenALLParameters_AllKeyValuesAddedDirectly() throws Exception {
+        Location loc = MockLocations.builder("MOCK", 12.193, 19.456)
+                .putExtra(BundleConstants.VDOP, "19").withTime(1457205869949l).build();
+        CustomUrlManager manager = new CustomUrlManager(null);
+        String expected = "http://192.168.1.65:8000/test?lat=12.193&lon=19.456&sat=0&desc=&alt=0.0" +
+                "&acc=0.0&dir=0.0&prov=MOCK&spd=0.0&timestamp=1457205869" +
+                "&timeoffset=2016-03-05T21:24:29.949+02:00&time=2016-03-05T19:24:29.949Z" +
+                "&starttimestamp=1495884681&date=2016-03-05&batt=0.0&ischarging=false&aid=&ser=" +
+                "&act=&filename=20170527abc&profile=Default+Profile&hdop=&vdop=19&pdop=&dist=0&";
+        String urlTemplate = "http://192.168.1.65:8000/test?%ALL";
+        assertThat("ALL parameter is substituted by all key values", manager.getFormattedTextblock(urlTemplate,
+                new SerializableLocation(loc), "", "", 0,
+                false, "", 1495884681283l,
+                "20170527abc", "Default Profile", 0),
+                is(expected));
+    }
+
+    @Test
+    public void getFormattedUrl_WhenALLParametersInBody_AllKeyValuesAddedDirectly() throws Exception {
+        Location loc = MockLocations.builder("MOCK", 12.193, 19.456)
+                .putExtra(BundleConstants.VDOP, "19").withTime(1457205869949l).build();
+        CustomUrlManager manager = new CustomUrlManager(null);
+        String expected = "lat=12.193&lon=19.456&sat=0&desc=&alt=0.0&acc=0.0&dir=0.0&prov=MOCK" +
+                "&spd=0.0&timestamp=1457205869&timeoffset=2016-03-05T21:24:29.949+02:00" +
+                "&time=2016-03-05T19:24:29.949Z&starttimestamp=1495884681&date=2016-03-05" +
+                "&batt=0.0&ischarging=false&aid=&ser=&act=&filename=20170527abc" +
+                "&profile=Default+Profile&hdop=&vdop=19&pdop=&dist=0&";
+        String urlTemplate = "%ALL";
+        assertThat("ALL parameter is substituted by all key values", manager.getFormattedTextblock(urlTemplate,
+                new SerializableLocation(loc), "", "", 0,
+                false, "", 1495884681283l,
+                "20170527abc", "Default Profile", 0),
+                is(expected));
+    }
+
 }


### PR DESCRIPTION
Issue #930

When switching profiles via automation, try to start logging again instead of waiting for time_before_logging to have elapsed.

Issue #951 

When closing the drawer, close the profile list.  
When clicking an item in the profile list, close the profile list, but keep the drawer open.   
(Limitation of the library, there's no method to keep the profile list open).  

Issue #944 

Custom URL parameter `%ALL` which gets replaced by every custom URL parameter available.  

Example:

    https://example.com/?%ALL

Results in

    https://example.com/?lat=37.421998333333335&lon=-122.084&sat=0&desc=&alt=5.0&acc=5.0&dir=0.0&prov=gps&spd=0.0&timestamp=1650655193&timeoffset=2022-04-22T20:19:53.228%2B01:00&time=2022-04-22T19:19:53.228Z&starttimestamp=1650655188&date=2022-04-22&batt=100.0&ischarging=false&aid=903204d9a916c36d&ser=903204d9a916c36d&act=&filename=20220422&profile=Default+Profile&hdop=&vdop=&pdop=&dist=0&

Issue #963 

Bugfix: properly escape the `+` as `%2B` in the time/timeoffset parameters in CustomURL