### PR TITLE
Milestone 123 - Conscrypt Provider, and notification on lock screen.

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/123.txt
+++ b/fastlane/metadata/android/en-US/changelogs/123.txt
@@ -1,0 +1,3 @@
+* Added option to allow showing GPSLogger notification on the lock screen.
+* For pre-Android 10 devices, option to install Conscrypt Provider if you need GPSLogger to connect to TLS 1.3 services or are having SSL connectivity issues.
+* Many updated translations from the Weblate community, thanks as always to all of you.

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/GpsLoggingService.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/GpsLoggingService.java
@@ -530,7 +530,7 @@ public class GpsLoggingService extends Service  {
                 channel.enableLights(false);
                 channel.enableVibration(false);
                 channel.setSound(null,null);
-                channel.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
+                channel.setLockscreenVisibility(preferenceHelper.shouldHideNotificationFromLockScreen() ? Notification.VISIBILITY_PRIVATE : Notification.VISIBILITY_PUBLIC);
 
                 channel.setShowBadge(true);
                 manager.createNotificationChannel(channel);
@@ -542,7 +542,7 @@ public class GpsLoggingService extends Service  {
                     .setLargeIcon(BitmapFactory.decodeResource(getResources(), R.mipmap.gpsloggericon3))
                     .setPriority( preferenceHelper.shouldHideNotificationFromStatusBar() ? NotificationCompat.PRIORITY_MIN : NotificationCompat.PRIORITY_LOW)
                     .setCategory(NotificationCompat.CATEGORY_SERVICE)
-                    .setVisibility(NotificationCompat.VISIBILITY_SECRET) //This hides the notification from lock screen
+                    .setVisibility(preferenceHelper.shouldHideNotificationFromLockScreen() ? NotificationCompat.VISIBILITY_SECRET : NotificationCompat.VISIBILITY_PUBLIC) //This hides the notification from lock screen
                     .setContentTitle(contentTitle)
                     .setContentText(contentText)
                     .setStyle(new NotificationCompat.BigTextStyle().bigText(contentText).setBigContentTitle(contentTitle))

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceHelper.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceHelper.java
@@ -486,6 +486,12 @@ public class PreferenceHelper {
         return prefs.getBoolean(PreferenceNames.HIDE_NOTIFICATION_FROM_STATUS_BAR, false);
     }
 
+    @ProfilePreference(name=PreferenceNames.HIDE_NOTIFICATION_FROM_LOCK_SCREEN)
+    public boolean shouldHideNotificationFromLockScreen(){
+        return prefs.getBoolean(PreferenceNames.HIDE_NOTIFICATION_FROM_LOCK_SCREEN, true);
+    }
+
+
     /**
      * Whether to display certain values using imperial units
      */

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceNames.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceNames.java
@@ -77,6 +77,7 @@ public  class PreferenceNames {
     public static final String OPENGTS_ACCOUNT_NAME = "opengts_accountname";
     public static final String HIDE_NOTIFICATION_BUTTONS = "hide_notification_buttons";
     public static final String HIDE_NOTIFICATION_FROM_STATUS_BAR = "hide_notification_from_status_bar";
+    public static final String HIDE_NOTIFICATION_FROM_LOCK_SCREEN = "hide_notification_from_lock_screen";
     public static final String DISPLAY_IMPERIAL = "useImperial";
 
     public static final String OPENSTREETMAP_ACCESS_TOKEN = "osm_accesstoken";

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/network/ConscryptProviderInstaller.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/network/ConscryptProviderInstaller.java
@@ -1,7 +1,9 @@
 package com.mendhak.gpslogger.common.network;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Build;
 import com.mendhak.gpslogger.common.Systems;
 import com.mendhak.gpslogger.common.slf4j.Logs;
@@ -80,4 +82,17 @@ public class ConscryptProviderInstaller {
         }
     }
 
+    public static Intent getConscryptInstallationIntent(Context context) {
+        // Default to Github
+        Intent conscryptIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://f-droid.org/en/packages/com.mendhak.conscryptprovider/"));
+
+        // If F-Droid client is installed, go straight to app listing
+        if(Systems.isPackageInstalled("org.fdroid.fdroid", context)){
+            conscryptIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("fdroid.app://details?id=com.mendhak.conscryptprovider"));
+        }
+
+        conscryptIntent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY | Intent.FLAG_ACTIVITY_CLEAR_WHEN_TASK_RESET);
+        return conscryptIntent;
+
+    }
 }

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/GeneralSettingsFragment.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/GeneralSettingsFragment.java
@@ -84,7 +84,11 @@ public class GeneralSettingsFragment extends PreferenceFragmentCompat implements
 
         setCoordinatesFormatPreferenceItem();
         setLanguagesPreferenceItem();
-        findPreference("install_conscrypt_provider").setEnabled(ConscryptProviderInstaller.shouldPromptUserForInstallation());
+        Preference conscryptPreference = findPreference("install_conscrypt_provider");
+        conscryptPreference.setEnabled(ConscryptProviderInstaller.shouldPromptUserForInstallation());
+        conscryptPreference.setIntent(ConscryptProviderInstaller.getConscryptInstallationIntent(getActivity()));
+
+
 
         Preference aboutInfo = findPreference("about_version_info");
         try {

--- a/gpslogger/src/main/res/xml/pref_general.xml
+++ b/gpslogger/src/main/res/xml/pref_general.xml
@@ -60,7 +60,7 @@
         >
         <intent
             android:action="android.intent.action.VIEW"
-            android:data="https://github.com/mendhak/Conscrypt-Provider/releases" />
+            android:data="https://f-droid.org/en/packages/com.mendhak.conscryptprovider/" />
     </Preference>
 
     <SwitchPreferenceCompat

--- a/gpslogger/src/main/res/xml/pref_general.xml
+++ b/gpslogger/src/main/res/xml/pref_general.xml
@@ -32,6 +32,13 @@
         app:iconSpaceReserved="false" />
 
     <SwitchPreferenceCompat
+        android:key="hide_notification_from_lock_screen"
+        android:title="Hide notification from lock screen"
+        android:summary="@string/restart_required"
+        android:defaultValue="true"
+        app:iconSpaceReserved="false"/>`
+
+    <SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="hide_notification_from_status_bar"
         android:summary="@string/restart_required"


### PR DESCRIPTION
Issue #990
Add option to show **notification on lock screen.** Default is to hide it though. 
![image](https://user-images.githubusercontent.com/746276/179398341-c3f91c52-8c82-4345-ab9a-aacc757e2852.png)

![image](https://user-images.githubusercontent.com/746276/179398255-ba4f7cb5-0217-4f09-a13a-c546539c6096.png)

Issue #971 #979 
Added ability to install a **Conscrypt Provider**, (a separate APK) which provides TLS 1.3 capabilities to the app when connecting to various services. 

![image](https://user-images.githubusercontent.com/746276/179398415-2115c486-60db-4d23-a786-c5808254a470.png)
