### PR TITLE
Generate FAQ section

### DIFF
--- a/assets/generate-pages/.eleventy.js
+++ b/assets/generate-pages/.eleventy.js
@@ -9,6 +9,7 @@ module.exports = (function (eleventyConfig) {
     // Copies the static and image files straight into the output folder, so that the HTML can reference it. 
     eleventyConfig.addPassthroughCopy({ "static/": "static" });
     eleventyConfig.addPassthroughCopy({ "content/images/": "images" });
+    eleventyConfig.addPassthroughCopy({ "faq/images/": "images" });
 
     // Don't process README.md, that's for me!
     eleventyConfig.ignores.add("README.md");
@@ -19,6 +20,10 @@ module.exports = (function (eleventyConfig) {
     // Collect all the tour.*.md files to go into the top Quick Tour section.
     eleventyConfig.addCollection('tour', function (collectionApi) {
         return collectionApi.getFilteredByGlob('content/tour*.*');
+    });
+
+    eleventyConfig.addCollection('faq', function (collectionApi) {
+        return collectionApi.getFilteredByGlob('faq/*.*');
     });
 
     // Collect all the more.*.md files to go into the More Screenshots section

--- a/assets/generate-pages/README.md
+++ b/assets/generate-pages/README.md
@@ -1,8 +1,9 @@
-Generates documentation using eleventy. 
+Generates documentation using eleventy.
+
+Docker compose volumes are used to ensure folders from parent directories are loaded into the working directory at the same level as the input folder configured in the .eleventy.js configuration.
 
 ```
-npm install
-npx eleventy --watch --serve
+docker-compose up
 ```
 
 Then browse to http://localhost:8080/
@@ -11,9 +12,9 @@ Then browse to http://localhost:8080/
 
 ## TODO
 
-Need to read Markdown files from `../text/faq` to populate the middle section of the page. 
+Need to read Markdown files from `../text/faq` to populate the middle section of the page. [DONE]
 
-Need to use a chain layout so that standalone pages can use the same stylesheet and layout.  
+Need to use a chain layout so that standalone pages can use the same stylesheet and layout.
 
 Need to generate standalone pages for `../text/opensource.md`, `../text/privacypolicy.md`, and `../text/faq/pages/gps-fix-details.md`
 

--- a/assets/generate-pages/docker-compose.yml
+++ b/assets/generate-pages/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3"
+services:
+  eleventy:
+    image: node:16-slim
+    volumes:
+      - ${PWD}:/app
+      - ${PWD}/../text/faq:/app/faq
+    working_dir: /app
+    command:
+      - /bin/sh
+      - -c
+      - |
+        npm install
+        npx -p @11ty/eleventy eleventy --watch --serve
+    ports:
+      - 8080:8080

--- a/assets/generate-pages/index.html
+++ b/assets/generate-pages/index.html
@@ -26,7 +26,7 @@
                 last as long as
                 possible.</section>
             <a href="#quick-tour" class="button">Tour</a>
-            <a href="#frequentlyaskedquestionsandissues" class="button">FAQ</a>
+            <a href="#frequently-asked-questions-and-issues" class="button">FAQ</a>
             <a href="#more-screenshots" class="button">Screenshots</a>
 
             <a href="https://github.com/mendhak/gpslogger/" class="pull-right">
@@ -55,7 +55,7 @@
 
             <hr />
 
-            {%- for item in collections.more -%}
+            {%- for item in collections.faq -%}
             <section>
                 <div class="lead">
                     {{ item.templateContent }}
@@ -64,7 +64,16 @@
             </section>
             {%- endfor -%}
 
+            <hr />
 
+            {%- for item in collections.more -%}
+            <section>
+                <div class="lead">
+                    {{ item.templateContent }}
+
+                </div>
+            </section>
+            {%- endfor -%}
         </main>
     </div>
 

--- a/assets/text/faq/faq.11tydata.json
+++ b/assets/text/faq/faq.11tydata.json
@@ -1,0 +1,3 @@
+{
+    "permalink": false
+}


### PR DESCRIPTION
Code change requires docker-compose to set up the working folder structure to play nice with eleventy.

docker-compose.yml also runs the npm install && npx eleventy to generate the site.

Fixed the FAQ button to jump to the FAQ section properly.

Added faq.11tydata.json file to assets/text/faq folder to disable html generation for the md files.