### PR TITLE
Add flag to custom url logging which can disable queueing requests while being offline

### DIFF
--- a/assets/text/faq/faq16-custom-url.md
+++ b/assets/text/faq/faq16-custom-url.md
@@ -8,7 +8,7 @@ Tap the Parameters to see a list of available parameters that you can use, inclu
 
 You can add your HTTP body, HTTP header, HTTP method and basic authentication credentials in the Custom URL screen.
 
-If your phone goes **offline**, then the app will queue these requests until a data connection becomes available.     
+If your phone goes **offline**, then the app will queue these requests until a data connection becomes available. This behavior can be changed with the 'Discard offline locations' toggle.
 
 If you use a self signed **SSL** certificate, be sure to [validate it first](#customsslcertificates).
 
@@ -16,6 +16,7 @@ The 'Log to custom URL' toggle will send an HTTP request each time the app acqui
 
 The 'Allow auto sending' toggle will also enable CSV logging out of necessity, and this feature will then make many requests to the Custom URL, one for each line in the recorded CSV.  It does this at the auto-send interval which is by default 60 minutes.  If you are writing these points to a database for example, it is your responsibility to 'deduplicate' when receiving these requests, for that reason it's a good idea to send a timestamp along.  
 
+The 'Discard offline locations' toggle will disable queueing the log requests while the phone is offline. It will always only keep the request with most recent location. This prevents sending many requests when the phone becomes online after a long period of time. You can enable this toggle if you are interested only in the most recent location. The auto sending feature is not affected by this toggle.
 
 
 

--- a/fastlane/metadata/android/en-US/changelogs/125.txt
+++ b/fastlane/metadata/android/en-US/changelogs/125.txt
@@ -1,2 +1,2 @@
 * Custom URL - added option to discard offline locations; this allows sending latest location only.
-* Custom URL will retry maximum 3 times instead of 5 times.
+* Custom URL - will retry maximum 3 times instead of 5 times.

--- a/fastlane/metadata/android/en-US/changelogs/125.txt
+++ b/fastlane/metadata/android/en-US/changelogs/125.txt
@@ -1,2 +1,2 @@
-* Custom URL - added option to discard offline locations; this allows sending latest location only.
+* Custom URL - added option to discard offline locations; useful for sending latest location.
 * Custom URL - will retry maximum 3 times instead of 5 times.

--- a/fastlane/metadata/android/en-US/changelogs/125.txt
+++ b/fastlane/metadata/android/en-US/changelogs/125.txt
@@ -1,0 +1,2 @@
+* Custom URL - added option to discard offline locations; this allows sending latest location only.
+* Custom URL will retry maximum 3 times instead of 5 times.

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceHelper.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceHelper.java
@@ -673,6 +673,11 @@ public class PreferenceHelper {
         return prefs.getBoolean(PreferenceNames.AUTOSEND_CUSTOMURL_ENABLED, false);
     }
 
+    @ProfilePreference(name= PreferenceNames.LOG_TO_URL_DISCARD_OFFLINE_LOCATIONS_ENABLED)
+    public boolean shouldCustomURLLoggingDiscardOfflineLocations() {
+        return prefs.getBoolean(PreferenceNames.LOG_TO_URL_DISCARD_OFFLINE_LOCATIONS_ENABLED, false);
+    }
+
 
     /**
      * Whether to log to OpenGTS.  See their <a href="http://opengts.sourceforge.net/OpenGTS_Config.pdf">installation guide</a>

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceNames.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceNames.java
@@ -44,6 +44,7 @@ public  class PreferenceNames {
     public static final String LOG_TO_URL_METHOD = "log_customurl_method";
     public static final String LOG_TO_URL_BASICAUTH_USERNAME = "log_customurl_basicauth_username";
     public static final String LOG_TO_URL_BASICAUTH_PASSWORD = "log_customurl_basicauth_password";
+    public static final String LOG_TO_URL_DISCARD_OFFLINE_LOCATIONS_ENABLED = "log_customurl_discard_offline_locations_enabled";
     public static final String AUTOSEND_CUSTOMURL_ENABLED = "autocustomurl_enabled";
     public static final String LOG_TO_OPENGTS = "log_opengts";
     public static final String LOG_PASSIVE_LOCATIONS="log_passive_locations";

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/FileLoggerFactory.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/FileLoggerFactory.java
@@ -86,8 +86,7 @@ public class FileLoggerFactory {
                     preferenceHelper.getCustomLoggingHTTPBody(),
                     preferenceHelper.getCustomLoggingHTTPHeaders(),
                     preferenceHelper.getCustomLoggingBasicAuthUsername(),
-                    preferenceHelper.getCustomLoggingBasicAuthPassword(),
-                    preferenceHelper.shouldCustomURLLoggingDiscardOfflineLocations()));
+                    preferenceHelper.getCustomLoggingBasicAuthPassword()));
         }
 
         if(preferenceHelper.shouldLogToGeoJSON()){

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/FileLoggerFactory.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/FileLoggerFactory.java
@@ -86,7 +86,8 @@ public class FileLoggerFactory {
                     preferenceHelper.getCustomLoggingHTTPBody(),
                     preferenceHelper.getCustomLoggingHTTPHeaders(),
                     preferenceHelper.getCustomLoggingBasicAuthUsername(),
-                    preferenceHelper.getCustomLoggingBasicAuthPassword()));
+                    preferenceHelper.getCustomLoggingBasicAuthPassword(),
+                    preferenceHelper.shouldCustomURLLoggingDiscardOfflineLocations()));
         }
 
         if(preferenceHelper.shouldLogToGeoJSON()){

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/customurl/CustomUrlJob.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/customurl/CustomUrlJob.java
@@ -23,6 +23,7 @@ package com.mendhak.gpslogger.loggers.customurl;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.birbit.android.jobqueue.CancelReason;
 import com.birbit.android.jobqueue.Job;
 import com.birbit.android.jobqueue.Params;
 import com.birbit.android.jobqueue.RetryConstraint;
@@ -48,14 +49,28 @@ public class CustomUrlJob extends Job {
 
     private static final Logger LOG = Logs.of(CustomUrlJob.class);
 
+    public static final String TAG_DISCARDABLE = "Discardable";
+
     private UploadEvents.BaseUploadEvent callbackEvent;
     private CustomUrlRequest urlRequest;
 
     public CustomUrlJob(CustomUrlRequest urlRequest, UploadEvents.BaseUploadEvent callbackEvent) {
-        super(new Params(1).requireNetwork().persist());
+        this(urlRequest, callbackEvent, null);
+    }
+
+    public CustomUrlJob(CustomUrlRequest urlRequest, UploadEvents.BaseUploadEvent callbackEvent, String tag) {
+        super(buildParams(tag));
 
         this.callbackEvent = callbackEvent;
         this.urlRequest = urlRequest;
+    }
+
+    private static Params buildParams(String tag) {
+        Params params = new Params(1).requireNetwork().persist();
+        if (tag != null && !"".equals(tag)) {
+            return params.addTags(tag);
+        }
+        return params;
     }
 
     @Override
@@ -98,8 +113,14 @@ public class CustomUrlJob extends Job {
 
     @Override
     protected void onCancel(int cancelReason, @Nullable Throwable throwable) {
-        EventBus.getDefault().post(callbackEvent.failed("Could not send to custom URL", throwable));
-        LOG.error("Custom URL: maximum attempts failed, giving up", throwable);
+        if (CancelReason.CANCELLED_WHILE_RUNNING == cancelReason) {
+            if (getTags() != null && getTags().contains(TAG_DISCARDABLE)) {
+                LOG.debug("Custom URL: cancelled sending outdated location");
+            }
+        } else if (CancelReason.REACHED_RETRY_LIMIT == cancelReason) {
+            EventBus.getDefault().post(callbackEvent.failed("Could not send to custom URL", throwable));
+            LOG.error("Custom URL: maximum attempts failed, giving up", throwable);
+        }
     }
 
     @Override

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/customurl/CustomUrlJob.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/customurl/CustomUrlJob.java
@@ -28,6 +28,7 @@ import com.birbit.android.jobqueue.Job;
 import com.birbit.android.jobqueue.Params;
 import com.birbit.android.jobqueue.RetryConstraint;
 import com.mendhak.gpslogger.common.AppSettings;
+import com.mendhak.gpslogger.common.Strings;
 import com.mendhak.gpslogger.common.events.UploadEvents;
 import com.mendhak.gpslogger.common.network.Networks;
 import com.mendhak.gpslogger.common.slf4j.Logs;
@@ -67,7 +68,7 @@ public class CustomUrlJob extends Job {
 
     private static Params buildParams(String tag) {
         Params params = new Params(1).requireNetwork().persist();
-        if (tag != null && !"".equals(tag)) {
+        if (!Strings.isNullOrEmpty(tag)) {
             return params.addTags(tag);
         }
         return params;

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/customurl/CustomUrlLogger.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/customurl/CustomUrlLogger.java
@@ -19,6 +19,8 @@
 
 package com.mendhak.gpslogger.loggers.customurl;
 
+import static com.mendhak.gpslogger.loggers.customurl.CustomUrlJob.TAG_DISCARDABLE;
+
 import android.content.Context;
 import android.location.Location;
 
@@ -89,8 +91,13 @@ public class CustomUrlLogger implements FileLogger {
                 PreferenceHelper.getInstance().getCurrentProfileName(),
                 Session.getInstance().getTotalTravelled());
 
-
-        manager.sendByHttp(finalUrl,httpMethod, finalBody, finalHeaders, basicAuthUsername, basicAuthPassword);
+        if (PreferenceHelper.getInstance().shouldCustomURLLoggingDiscardOfflineLocations()) {
+            manager.cancelHttpRequests(() ->
+                    manager.sendByHttp(finalUrl, httpMethod, finalBody, finalHeaders, basicAuthUsername, basicAuthPassword, TAG_DISCARDABLE),
+                    TAG_DISCARDABLE);
+        } else {
+            manager.sendByHttp(finalUrl, httpMethod, finalBody, finalHeaders, basicAuthUsername, basicAuthPassword);
+        }
 
     }
 

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/customurl/CustomUrlLogger.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/customurl/CustomUrlLogger.java
@@ -22,6 +22,7 @@ package com.mendhak.gpslogger.loggers.customurl;
 import android.content.Context;
 import android.location.Location;
 
+import com.mendhak.gpslogger.common.AppSettings;
 import com.mendhak.gpslogger.common.BatteryInfo;
 import com.mendhak.gpslogger.common.PreferenceHelper;
 import com.mendhak.gpslogger.common.SerializableLocation;
@@ -43,8 +44,11 @@ public class CustomUrlLogger implements FileLogger {
     private final String basicAuthUsername;
     private final String basicAuthPassword;
     private final boolean batteryCharging;
+    private final boolean shouldDiscardOfflineLocations;
 
-    public CustomUrlLogger(String customLoggingUrl, Context context, String httpMethod, String httpBody, String httpHeaders, String basicAuthUsername, String basicAuthPassword) {
+    public CustomUrlLogger(String customLoggingUrl, Context context, String httpMethod, String httpBody,
+                           String httpHeaders, String basicAuthUsername, String basicAuthPassword,
+                           boolean shouldDiscardOfflineLocations) {
         this.customLoggingUrl = customLoggingUrl;
         BatteryInfo batteryInfo = Systems.getBatteryInfo(context);
         this.batteryLevel = batteryInfo.BatteryLevel;
@@ -54,6 +58,7 @@ public class CustomUrlLogger implements FileLogger {
         this.httpHeaders = httpHeaders;
         this.basicAuthUsername = basicAuthUsername;
         this.basicAuthPassword = basicAuthPassword;
+        this.shouldDiscardOfflineLocations = shouldDiscardOfflineLocations;
     }
 
     @Override
@@ -65,6 +70,12 @@ public class CustomUrlLogger implements FileLogger {
 
     @Override
     public void annotate(String description, Location loc) throws Exception {
+
+        if(shouldDiscardOfflineLocations) {
+            if (!Systems.isNetworkAvailable(AppSettings.getInstance())) {
+                return;
+            }
+        }
 
         CustomUrlManager manager = new CustomUrlManager(PreferenceHelper.getInstance());
 

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/customurl/CustomUrlLogger.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/customurl/CustomUrlLogger.java
@@ -19,8 +19,6 @@
 
 package com.mendhak.gpslogger.loggers.customurl;
 
-import static com.mendhak.gpslogger.loggers.customurl.CustomUrlJob.TAG_DISCARDABLE;
-
 import android.content.Context;
 import android.location.Location;
 
@@ -91,13 +89,7 @@ public class CustomUrlLogger implements FileLogger {
                 PreferenceHelper.getInstance().getCurrentProfileName(),
                 Session.getInstance().getTotalTravelled());
 
-        if (PreferenceHelper.getInstance().shouldCustomURLLoggingDiscardOfflineLocations()) {
-            manager.cancelHttpRequests(() ->
-                    manager.sendByHttp(finalUrl, httpMethod, finalBody, finalHeaders, basicAuthUsername, basicAuthPassword, TAG_DISCARDABLE),
-                    TAG_DISCARDABLE);
-        } else {
-            manager.sendByHttp(finalUrl, httpMethod, finalBody, finalHeaders, basicAuthUsername, basicAuthPassword);
-        }
+        manager.sendByHttp(finalUrl, httpMethod, finalBody, finalHeaders, basicAuthUsername, basicAuthPassword);
 
     }
 

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/customurl/CustomUrlLogger.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/customurl/CustomUrlLogger.java
@@ -44,11 +44,9 @@ public class CustomUrlLogger implements FileLogger {
     private final String basicAuthUsername;
     private final String basicAuthPassword;
     private final boolean batteryCharging;
-    private final boolean shouldDiscardOfflineLocations;
 
     public CustomUrlLogger(String customLoggingUrl, Context context, String httpMethod, String httpBody,
-                           String httpHeaders, String basicAuthUsername, String basicAuthPassword,
-                           boolean shouldDiscardOfflineLocations) {
+                           String httpHeaders, String basicAuthUsername, String basicAuthPassword) {
         this.customLoggingUrl = customLoggingUrl;
         BatteryInfo batteryInfo = Systems.getBatteryInfo(context);
         this.batteryLevel = batteryInfo.BatteryLevel;
@@ -58,7 +56,6 @@ public class CustomUrlLogger implements FileLogger {
         this.httpHeaders = httpHeaders;
         this.basicAuthUsername = basicAuthUsername;
         this.basicAuthPassword = basicAuthPassword;
-        this.shouldDiscardOfflineLocations = shouldDiscardOfflineLocations;
     }
 
     @Override
@@ -71,7 +68,7 @@ public class CustomUrlLogger implements FileLogger {
     @Override
     public void annotate(String description, Location loc) throws Exception {
 
-        if(shouldDiscardOfflineLocations) {
+        if(PreferenceHelper.getInstance().shouldCustomURLLoggingDiscardOfflineLocations()) {
             if (!Systems.isNetworkAvailable(AppSettings.getInstance())) {
                 return;
             }
@@ -101,7 +98,6 @@ public class CustomUrlLogger implements FileLogger {
                 Session.getInstance().getTotalTravelled());
 
         manager.sendByHttp(finalUrl, httpMethod, finalBody, finalHeaders, basicAuthUsername, basicAuthPassword);
-
     }
 
 

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManager.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManager.java
@@ -177,6 +177,10 @@ public class CustomUrlManager extends FileSender {
 
     public void sendByHttp(String url, String method, String body, String headers, String username, String password){
         if(preferenceHelper.shouldCustomURLLoggingDiscardOfflineLocations()){
+            if(!Systems.isNetworkAvailable(AppSettings.getInstance())){
+                LOG.debug("Device offline, will not log to Custom URL");
+                return;
+            }
             AppSettings.getJobManager().cancelJobsInBackground(cancelResult -> {
                 debugIfNotEmpty(cancelResult.getCancelledJobs(), "Custom URL: cancelled %d http requests with outdated locations");
                 debugIfNotEmpty(cancelResult.getFailedToCancel(), "Custom URL: failed to cancel %d http requests with outdated locations");

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManager.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManager.java
@@ -177,10 +177,6 @@ public class CustomUrlManager extends FileSender {
 
     public void sendByHttp(String url, String method, String body, String headers, String username, String password){
         if(preferenceHelper.shouldCustomURLLoggingDiscardOfflineLocations()){
-            if(!Systems.isNetworkAvailable(AppSettings.getInstance())){
-                LOG.debug("Device offline, will not log to Custom URL");
-                return;
-            }
             AppSettings.getJobManager().cancelJobsInBackground(cancelResult -> {
                 debugIfNotEmpty(cancelResult.getCancelledJobs(), "Custom URL: cancelled %d http requests with outdated locations");
                 debugIfNotEmpty(cancelResult.getFailedToCancel(), "Custom URL: failed to cancel %d http requests with outdated locations");

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManager.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManager.java
@@ -172,13 +172,6 @@ public class CustomUrlManager extends FileSender {
     }
 
     public void sendByHttp(String url, String method, String body, String headers, String username, String password){
-        if(preferenceHelper.shouldCustomURLLoggingDiscardOfflineLocations()) {
-            if (!Systems.isNetworkAvailable(AppSettings.getInstance())) {
-                LOG.debug("Device offline, will not log to Custom URL");
-                return;
-            }
-        }
-
         JobManager jobManager = AppSettings.getJobManager();
         jobManager.addJobInBackground(new CustomUrlJob(new CustomUrlRequest(url, method,
                 body, headers, username, password), new UploadEvents.CustomUrl()));

--- a/gpslogger/src/main/res/values-hu/strings.xml
+++ b/gpslogger/src/main/res/values-hu/strings.xml
@@ -377,4 +377,6 @@
     <string name="install_conscrypt_provider_summary">Ha régebbi Android-eszközökön SSL/TLS csatlakozási problémákat tapasztal, a Conscrypt Provider telepítése segíthet. (Kövesse ezt a linket, telepítse az APK-t, majd indítsa újra az alkalmazást)</string>
     <string name="autosend_customurl_summary">(Ez a funkció lehetővé teszi a CSV-naplózást) Tömegesen küld kéréseket az egyéni URL-re, a CSV-fájl minden sorához egyet. Az automatikus küldési időköztől függ.</string>
     <string name="log_customurl_summary_detailed">Kérést küld az egyéni URL-címre, amikor egy helypont rögzítésre kerül. a naplózási intervallumtól függ.</string>
+    <string name="log_customurl_discard_offline_locations">Offline helyadatokat eldobása</string>
+    <string name="log_customurl_discard_offline_locations_summary">Csak a legújabb helyadatokat naplózza az egyéni URL-re miután a hálózati kapcsolat helyreállt. (Nincs hatással az automatikus küldésre)</string>
 </resources>

--- a/gpslogger/src/main/res/values/strings.xml
+++ b/gpslogger/src/main/res/values/strings.xml
@@ -342,7 +342,7 @@
     <string name="log_customurl_summary">Send logging info to your own server over HTTP</string>
     <string name="autosend_customurl_summary">(This feature enables CSV logging) Sends requests in bulk to the Custom URL, one for each line in the CSV file. Depends on the auto-send interval.</string>
     <string name="log_customurl_discard_offline_locations">Discard offline locations</string>
-    <string name="log_customurl_discard_offline_locations_summary">Log locations to Custom URL only while a network connection is available</string>
+    <string name="log_customurl_discard_offline_locations_summary">Log locations to Custom URL only while a network connection is available (does not affect auto send)</string>
 
     <string name="txt_annotation">Annotation:</string>
     <string name="txt_time_isoformat">Time UTC (2011-12-25T15:27:33Z):</string>

--- a/gpslogger/src/main/res/values/strings.xml
+++ b/gpslogger/src/main/res/values/strings.xml
@@ -342,7 +342,7 @@
     <string name="log_customurl_summary">Send logging info to your own server over HTTP</string>
     <string name="autosend_customurl_summary">(This feature enables CSV logging) Sends requests in bulk to the Custom URL, one for each line in the CSV file. Depends on the auto-send interval.</string>
     <string name="log_customurl_discard_offline_locations">Discard offline locations</string>
-    <string name="log_customurl_discard_offline_locations_summary">Log only the most recent location to Custom URL after network connection restored. (This has no effect on auto send)</string>
+    <string name="log_customurl_discard_offline_locations_summary">Log locations to Custom URL only while a network connection is available</string>
 
     <string name="txt_annotation">Annotation:</string>
     <string name="txt_time_isoformat">Time UTC (2011-12-25T15:27:33Z):</string>

--- a/gpslogger/src/main/res/values/strings.xml
+++ b/gpslogger/src/main/res/values/strings.xml
@@ -341,6 +341,8 @@
     <string name="log_customurl_setup_title">Custom URL</string>
     <string name="log_customurl_summary">Send logging info to your own server over HTTP</string>
     <string name="autosend_customurl_summary">(This feature enables CSV logging) Sends requests in bulk to the Custom URL, one for each line in the CSV file. Depends on the auto-send interval.</string>
+    <string name="log_customurl_discard_offline_locations">Discard offline locations</string>
+    <string name="log_customurl_discard_offline_locations_summary">Log only the most recent location to Custom URL after network connection restored. (This has no effect on auto send)</string>
 
     <string name="txt_annotation">Annotation:</string>
     <string name="txt_time_isoformat">Time UTC (2011-12-25T15:27:33Z):</string>

--- a/gpslogger/src/main/res/xml/customurlsettings.xml
+++ b/gpslogger/src/main/res/xml/customurlsettings.xml
@@ -14,6 +14,12 @@
         android:summary="@string/autosend_customurl_summary"
         app:iconSpaceReserved="false" />
 
+    <SwitchPreferenceCompat
+        android:key="log_customurl_discard_offline_locations_enabled"
+        android:title="@string/log_customurl_discard_offline_locations"
+        android:summary="@string/log_customurl_discard_offline_locations_summary"
+        app:iconSpaceReserved="false" />
+
     <Preference
         android:key="log_customurl_url"
         android:singleLine="true"


### PR DESCRIPTION
Issue #1025

This change is to solve the following use case:
* Logging interval is 15 seconds.
* Custom url logging is enabled.
* There is no network connection for 3 hours.
* A custom url call takes around 500 milliseconds.
* This means after the phone has network connection again, it will take 6 minutes to send the queued requests.
* If only the current location is relevant for the user, there is no need to send all the previous locations. This decreases the number of requests and the delay until the current location is sent to the server.

A new switch is added to the customurlsettings page. This is false by default. In this case everything works as before.

If the flag is set to true, old custom url log jobs tagged with 'Discardable' will be removed from the queue when a new job is created. This way when the network connection is restored, only one custom url log job will be in the queue which will contain the latest location.

This change does not affect in any way the auto-send to custom url (when a list of calls are made based on the csv file content). Jobs created for auto send are not tagged with 'Discardable' and won't be cancelled by the log jobs.