### PR TITLE
Use exact alarms for auto send timers

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/GpsLoggingService.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/GpsLoggingService.java
@@ -20,7 +20,6 @@
 package com.mendhak.gpslogger;
 
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.app.*;
 import android.content.Context;
 import android.content.Intent;
@@ -304,7 +303,6 @@ public class GpsLoggingService extends Service  {
     /**
      * Sets up the auto email timers based on user preferences.
      */
-    @TargetApi(23)
     public void setupAutoSendTimers() {
         LOG.debug("Setting up autosend timers. Auto Send Enabled - " + String.valueOf(preferenceHelper.isAutoSendEnabled())
                 + ", Auto Send Delay - " + String.valueOf(session.getAutoSendDelay()));
@@ -317,8 +315,8 @@ public class GpsLoggingService extends Service  {
 
             PendingIntent sender = PendingIntent.getBroadcast(this, 0, alarmIntent, PendingIntent.FLAG_UPDATE_CURRENT);
             AlarmManager am = (AlarmManager) getSystemService(ALARM_SERVICE);
-            if(Systems.isDozing(this)) {
-                am.setAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerTime, sender);
+            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                am.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerTime, sender);
             }
             else {
                 am.set(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerTime, sender);


### PR DESCRIPTION
Issue #999

The use case was that after an Android version update the auto send did not run every minute anymore as defined in settings, but ran only every 5 minutes when the phone was idle.

This is based on commits ee96c9bd and e9521818 where a similar change was made with the alarms used for the logging interval.
The related issue is #969.

With `setAndAllowWhileIdle` the alarm might be delayed after the specified time passed when the phone is idle, while with `setExactAndAllowWhileIdle` the system will try to trigger the alarm exactly at the defined time.