### PR TITLE
Fix monochrome icon

### DIFF
--- a/gpslogger/src/main/res/drawable/gpslogger_monochrome.xml
+++ b/gpslogger/src/main/res/drawable/gpslogger_monochrome.xml
@@ -1,8 +1,3 @@
-<inset xmlns:android="http://schemas.android.com/apk/res/android"
-    android:insetLeft="16dp"
-    android:insetTop="16dp"
-    android:insetRight="16dp"
-    android:insetBottom="16dp">
 <vector android:height="500dp" android:viewportHeight="28.575"
     android:viewportWidth="28.575" android:width="500dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#ffffff"
@@ -160,4 +155,3 @@
         android:pathData="m10.39,18.807c-0.075,-0.027 -0.128,-0.07 -0.308,-0.252 -0.146,-0.148 -0.175,-0.181 -0.2,-0.233 -0.028,-0.058 -0.03,-0.066 -0.03,-0.153 0,-0.089 0.001,-0.095 0.032,-0.158 0.04,-0.08 0.098,-0.137 0.179,-0.176 0.054,-0.026 0.065,-0.028 0.15,-0.028 0.085,0 0.096,0.002 0.152,0.029 0.053,0.025 0.084,0.052 0.239,0.205 0.098,0.097 0.193,0.199 0.212,0.227 0.046,0.07 0.066,0.161 0.053,0.239 -0.021,0.125 -0.097,0.228 -0.208,0.283 -0.052,0.025 -0.068,0.029 -0.142,0.031 -0.065,0.002 -0.094,-0.001 -0.13,-0.014z"
         android:strokeColor="#ffffff" android:strokeWidth="0.009"/>
 </vector>
-</inset>


### PR DESCRIPTION
The inset in the monochrome icon seems to break the icon when using certain themes. (In my case using the default theme on Nothing OS 2.0). Removing the inset makes the icon display properly.

Current icon:
![pre](https://github.com/mendhak/gpslogger/assets/6852884/9db7cc8f-069d-48b7-a402-89200b9a65f2)

After removing the inset:
![post](https://github.com/mendhak/gpslogger/assets/6852884/fb59b4ee-5f34-499a-9361-779b582fde50)
