### PR TITLE
Feature: flyingOwl/custom_url_speed_in_kph

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManager.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManager.java
@@ -197,6 +197,7 @@ public class CustomUrlManager extends FileSender {
         replacements.put("acc", String.valueOf(sLoc.getAccuracy()));
         replacements.put("dir", String.valueOf(sLoc.getBearing()));
         replacements.put("prov", String.valueOf(sLoc.getProvider()));
+        replacements.put("spd_kph", String.valueOf(sLoc.getSpeed()*3.6));
         replacements.put("spd", String.valueOf(sLoc.getSpeed()));
         replacements.put("timestamp", String.valueOf(sLoc.getTime()/1000));
 

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/CustomUrlFragment.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/CustomUrlFragment.java
@@ -116,31 +116,33 @@ public class CustomUrlFragment extends PreferenceFragmentCompat implements
                             "{3} <font color=''#{0}'' face=''monospace''>%DESC</font><br />" +
                             "{4} <font color=''#{0}'' face=''monospace''>%SAT</font><br />" +
                             "{5} <font color=''#{0}'' face=''monospace''>%ALT</font><br />" +
-                            "{6} <font color=''#{0}'' face=''monospace''>%SPD</font><br />" +
-                            "{7} <font color=''#{0}'' face=''monospace''>%ACC</font><br />" +
-                            "{8} <font color=''#{0}'' face=''monospace''>%DIR</font><br />" +
-                            "{9} <font color=''#{0}'' face=''monospace''>%PROV</font><br />" +
-                            "{10} <font color=''#{0}'' face=''monospace''>%TIMESTAMP</font><br />" +
-                            "{11} <font color=''#{0}'' face=''monospace''>%TIME</font><br />" +
-                            "{12} <font color=''#{0}'' face=''monospace''>%TIMEOFFSET</font><br />" +
-                            "{13} <font color=''#{0}'' face=''monospace''>%DATE</font><br />" +
-                            "{14} <font color=''#{0}'' face=''monospace''>%STARTTIMESTAMP</font><br />" +
-                            "{15} <font color=''#{0}'' face=''monospace''>%BATT</font><br />" +
-                            "{16} <font color=''#{0}'' face=''monospace''>%ISCHARGING</font><br />" +
-                            "{17} <font color=''#{0}'' face=''monospace''>%AID</font><br />" +
-                            "{18} <font color=''#{0}'' face=''monospace''>%SER</font><br />" +
-                            "{19} <font color=''#{0}'' face=''monospace''>%FILENAME</font><br />" +
-                            "{20} <font color=''#{0}'' face=''monospace''>%PROFILE</font><br />" +
-                            "{21} <font color=''#{0}'' face=''monospace''>%HDOP</font><br />" +
-                            "{22} <font color=''#{0}'' face=''monospace''>%VDOP</font><br />" +
-                            "{23} <font color=''#{0}'' face=''monospace''>%PDOP</font><br />" +
-                            "{24} <font color=''#{0}'' face=''monospace''>%DIST</font><br />" +
-                            "{25} <font color=''#{0}'' face=''monospace''>%ALL</font>";
+                            "{6} <font color=''#{0}'' face=''monospace''>%SPD_KPH</font><br />" +
+                            "{7} <font color=''#{0}'' face=''monospace''>%SPD</font><br />" +
+                            "{8} <font color=''#{0}'' face=''monospace''>%ACC</font><br />" +
+                            "{9} <font color=''#{0}'' face=''monospace''>%DIR</font><br />" +
+                            "{10} <font color=''#{0}'' face=''monospace''>%PROV</font><br />" +
+                            "{11} <font color=''#{0}'' face=''monospace''>%TIMESTAMP</font><br />" +
+                            "{12} <font color=''#{0}'' face=''monospace''>%TIME</font><br />" +
+                            "{13} <font color=''#{0}'' face=''monospace''>%TIMEOFFSET</font><br />" +
+                            "{14} <font color=''#{0}'' face=''monospace''>%DATE</font><br />" +
+                            "{15} <font color=''#{0}'' face=''monospace''>%STARTTIMESTAMP</font><br />" +
+                            "{16} <font color=''#{0}'' face=''monospace''>%BATT</font><br />" +
+                            "{17} <font color=''#{0}'' face=''monospace''>%ISCHARGING</font><br />" +
+                            "{18} <font color=''#{0}'' face=''monospace''>%AID</font><br />" +
+                            "{19} <font color=''#{0}'' face=''monospace''>%SER</font><br />" +
+                            "{20} <font color=''#{0}'' face=''monospace''>%FILENAME</font><br />" +
+                            "{21} <font color=''#{0}'' face=''monospace''>%PROFILE</font><br />" +
+                            "{22} <font color=''#{0}'' face=''monospace''>%HDOP</font><br />" +
+                            "{23} <font color=''#{0}'' face=''monospace''>%VDOP</font><br />" +
+                            "{24} <font color=''#{0}'' face=''monospace''>%PDOP</font><br />" +
+                            "{25} <font color=''#{0}'' face=''monospace''>%DIST</font><br />" +
+                            "{26} <font color=''#{0}'' face=''monospace''>%ALL</font>";
             String legend1 = MessageFormat.format(legendFormat,
                     codeGreen,
                     getString(R.string.txt_latitude), getString(R.string.txt_longitude), getString(R.string.txt_annotation),
-                    getString(R.string.txt_satellites), getString(R.string.txt_altitude), getString(R.string.txt_speed),
-                    getString(R.string.txt_accuracy), getString(R.string.txt_direction), getString(R.string.txt_provider),
+                    getString(R.string.txt_satellites), getString(R.string.txt_altitude), getString(R.string.txt_speed_kph),
+                    getString(R.string.txt_speed), getString(R.string.txt_accuracy), getString(R.string.txt_direction),
+                    getString(R.string.txt_provider),
                     getString(R.string.txt_timestamp_epoch),
                     getString(R.string.txt_time_isoformat),
                     getString(R.string.txt_time_with_offset_isoformat),

--- a/gpslogger/src/main/res/values/strings.xml
+++ b/gpslogger/src/main/res/values/strings.xml
@@ -26,6 +26,7 @@
     <string name="txt_latitude">Latitude:</string>
     <string name="txt_longitude">Longitude:</string>
     <string name="txt_altitude">Altitude:</string>
+    <string name="txt_speed_kph">Speed (in km/h):</string>
     <string name="txt_speed">Speed:</string>
     <string name="txt_direction">Direction:</string>
     <string name="txt_satellites">Satellites:</string>

--- a/gpslogger/src/test/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManagerTest.java
+++ b/gpslogger/src/test/java/com/mendhak/gpslogger/senders/customurl/CustomUrlManagerTest.java
@@ -27,15 +27,15 @@ public class CustomUrlManagerTest {
                 .withAltitude(45)
                 .withAccuracy(8)
                 .withBearing(359)
-                .withSpeed(9001)
+                .withSpeed(9005)
                 .withTime(1457205869949l)
                 .build();
 
 
         CustomUrlManager manager = new CustomUrlManager(null);
 
-        String expected = "http://192.168.1.65:8000/test?lat=12.193&lon=19.111&sat=9&desc=blah&alt=45.0&acc=8.0&dir=359.0&prov=MOCK&spd=9001.0&time=2016-03-05T19:24:29.949Z&battery=91.0&androidId=22&serial=SRS11&activity=";
-        String urlTemplate = "http://192.168.1.65:8000/test?lat=%LAT&lon=%LON&sat=%SAT&desc=%DESC&alt=%ALT&acc=%ACC&dir=%DIR&prov=%PROV&spd=%SPD&time=%TIME&battery=%BATT&androidId=%AID&serial=%SER&activity=%act";
+        String expected = "http://192.168.1.65:8000/test?lat=12.193&lon=19.111&sat=9&desc=blah&alt=45.0&acc=8.0&dir=359.0&prov=MOCK&spd_kph=32418.0&spd=9005.0&time=2016-03-05T19:24:29.949Z&battery=91.0&androidId=22&serial=SRS11&activity=";
+        String urlTemplate = "http://192.168.1.65:8000/test?lat=%LAT&lon=%LON&sat=%SAT&desc=%DESC&alt=%ALT&acc=%ACC&dir=%DIR&prov=%PROV&spd_kph=%SPD_KPH&spd=%SPD&time=%TIME&battery=%BATT&androidId=%AID&serial=%SER&activity=%act";
         assertThat("Placeholders are substituted", manager.getFormattedTextblock(urlTemplate,
                 new SerializableLocation(loc), "blah", "22", 91,
                 false, "SRS11", 0, "", "",
@@ -289,7 +289,7 @@ public class CustomUrlManagerTest {
                 .putExtra(BundleConstants.VDOP, "19").withTime(1457205869949l).build();
         CustomUrlManager manager = new CustomUrlManager(null);
         String expected = "http://192.168.1.65:8000/test?lat=12.193&lon=19.456&sat=0&desc=&alt=0.0" +
-                "&acc=0.0&dir=0.0&prov=MOCK&spd=0.0&timestamp=1457205869" +
+                "&acc=0.0&dir=0.0&prov=MOCK&spd_kph=0.0&spd=0.0&timestamp=1457205869" +
                 "&timeoffset=2016-03-05T21:24:29.949%2B02:00&time=2016-03-05T19:24:29.949Z" +
                 "&starttimestamp=1495884681&date=2016-03-05&batt=0.0&ischarging=false&aid=&ser=" +
                 "&act=&filename=20170527abc&profile=Default+Profile&hdop=&vdop=19&pdop=&dist=0&";
@@ -307,7 +307,7 @@ public class CustomUrlManagerTest {
                 .putExtra(BundleConstants.VDOP, "19").withTime(1457205869949l).build();
         CustomUrlManager manager = new CustomUrlManager(null);
         String expected = "lat=12.193&lon=19.456&sat=0&desc=&alt=0.0&acc=0.0&dir=0.0&prov=MOCK" +
-                "&spd=0.0&timestamp=1457205869&timeoffset=2016-03-05T21:24:29.949%2B02:00" +
+                "&spd_kph=0.0&spd=0.0&timestamp=1457205869&timeoffset=2016-03-05T21:24:29.949%2B02:00" +
                 "&time=2016-03-05T19:24:29.949Z&starttimestamp=1495884681&date=2016-03-05" +
                 "&batt=0.0&ischarging=false&aid=&ser=&act=&filename=20170527abc" +
                 "&profile=Default+Profile&hdop=&vdop=19&pdop=&dist=0&";


### PR DESCRIPTION
Fixes #1139 

Add "%SPD_KPH" to parameter description dialog, add unit tests and modify speed values so floating point precision does not produce weird looking strings (e.g. 9001.0 * 3.6 = "32403.60000000004")