### PR TITLE
Added android.permission.FOREGROUND_SERVICE_LOCATION to manifest.

### DIFF
--- a/gpslogger/src/main/AndroidManifest.xml
+++ b/gpslogger/src/main/AndroidManifest.xml
@@ -28,6 +28,8 @@
 
     <!-- allow this to run as a foreground service -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!-- Beginning with Android 14 (API level 34), this is necessary. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
 
 
     <application


### PR DESCRIPTION
[Official documentation](https://developer.android.com/develop/background-work/services/fg-service-types) states:

> Beginning with Android 14 (API level 34), you must declare an appropriate service type for each foreground service. That means you must declare the service type in your app manifest, and also request the appropriate foreground service permission for that type (in addition to requesting the [FOREGROUND_SERVICE](https://developer.android.com/reference/android/Manifest.permission#FOREGROUND_SERVICE) permission).

Since the app is declaring a service with `android:foregroundServiceType="location"`, [location section](https://developer.android.com/develop/background-work/services/fg-service-types#location) of the documentation specifies that permission `FOREGROUND_SERVICE_LOCATION` needs to be declared in manifest file.