### PR TITLE
Add passive data collection interval setting to prevent excessive data generation.

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/GeneralLocationListener.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/GeneralLocationListener.java
@@ -21,6 +21,7 @@ package com.mendhak.gpslogger;
 
 import android.location.*;
 import android.os.Bundle;
+import com.mendhak.gpslogger.common.PreferenceHelper;
 import com.mendhak.gpslogger.common.BundleConstants;
 import com.mendhak.gpslogger.common.Session;
 import com.mendhak.gpslogger.common.Strings;
@@ -32,6 +33,8 @@ import java.util.Iterator;
 
 class GeneralLocationListener implements LocationListener, GpsStatus.Listener, GpsStatus.NmeaListener {
 
+    private long lastUpdateTime = 0;
+    private PreferenceHelper preferenceHelper = PreferenceHelper.getInstance();
     private String listenerName;
     private static GpsLoggingService loggingService;
     private static final Logger LOG = Logs.of(GeneralLocationListener.class);
@@ -69,8 +72,17 @@ class GeneralLocationListener implements LocationListener, GpsStatus.Listener, G
                 b.putInt(BundleConstants.SATELLITES_FIX, satellitesUsedInFix);
 
                 loc.setExtras(b);
-                loggingService.onLocationChanged(loc);
 
+                if (listenerName.equalsIgnoreCase(BundleConstants.PASSIVE)){
+                    long now = System.currentTimeMillis();
+                    LOG.debug("Passive location listener Interval " + (preferenceHelper.getPassiveFilterInterval() * 1000) + "ms");
+                    if (now - lastUpdateTime >= (preferenceHelper.getPassiveFilterInterval() * 1000)) {
+                        lastUpdateTime = now;
+                        loggingService.onLocationChanged(loc);
+                    }
+                }else{
+                    loggingService.onLocationChanged(loc);
+                }
                 this.latestHdop = "";
                 this.latestPdop = "";
                 this.latestVdop = "";

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/GeneralLocationListener.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/GeneralLocationListener.java
@@ -21,7 +21,6 @@ package com.mendhak.gpslogger;
 
 import android.location.*;
 import android.os.Bundle;
-import com.mendhak.gpslogger.common.PreferenceHelper;
 import com.mendhak.gpslogger.common.BundleConstants;
 import com.mendhak.gpslogger.common.Session;
 import com.mendhak.gpslogger.common.Strings;
@@ -33,8 +32,6 @@ import java.util.Iterator;
 
 class GeneralLocationListener implements LocationListener, GpsStatus.Listener, GpsStatus.NmeaListener {
 
-    private long lastUpdateTime = 0;
-    private PreferenceHelper preferenceHelper = PreferenceHelper.getInstance();
     private String listenerName;
     private static GpsLoggingService loggingService;
     private static final Logger LOG = Logs.of(GeneralLocationListener.class);
@@ -72,17 +69,8 @@ class GeneralLocationListener implements LocationListener, GpsStatus.Listener, G
                 b.putInt(BundleConstants.SATELLITES_FIX, satellitesUsedInFix);
 
                 loc.setExtras(b);
+                loggingService.onLocationChanged(loc);
 
-                if (listenerName.equalsIgnoreCase(BundleConstants.PASSIVE)){
-                    long now = System.currentTimeMillis();
-                    LOG.debug("Passive location listener Interval " + (preferenceHelper.getPassiveFilterInterval() * 1000) + "ms");
-                    if (now - lastUpdateTime >= (preferenceHelper.getPassiveFilterInterval() * 1000)) {
-                        lastUpdateTime = now;
-                        loggingService.onLocationChanged(loc);
-                    }
-                }else{
-                    loggingService.onLocationChanged(loc);
-                }
                 this.latestHdop = "";
                 this.latestPdop = "";
                 this.latestVdop = "";

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/GpsLoggingService.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/GpsLoggingService.java
@@ -888,6 +888,17 @@ public class GpsLoggingService extends Service  {
             return;
         }
 
+        // Even if it's a passive location, the loc.getTime() - session.getLatestPassiveTimeStamp()  should be greater than the previous getPassiveFilterInterval's time.
+        if(isPassiveLocation && session.getPreviousLocationInfo() != null ){
+            if  ((loc.getTime() - session.getLatestPassiveTimeStamp()) < (preferenceHelper.getPassiveFilterInterval() * 1000)) {
+                LOG.debug("Passive location listener Interval set=>{}ms old=>{}ms now=>{}ms Filter",(preferenceHelper.getPassiveFilterInterval() * 1000), session.getLatestPassiveTimeStamp(), loc.getTime() );
+                return;
+            }
+            //If passed, save LatestPassiveTimeStamp.
+            session.setLatestPassiveTimeStamp(loc.getTime());
+            LOG.debug("Passive location listener Interval set=>{}ms old=>{}ms now=>{}ms Pass",(preferenceHelper.getPassiveFilterInterval() * 1000), session.getLatestPassiveTimeStamp(), loc.getTime() );
+        }
+
 
         //Don't log a point if user has been still
         // However, if user has set an annotation, just log the point, disregard time and distance filters

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/GpsLoggingService.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/GpsLoggingService.java
@@ -279,6 +279,13 @@ public class GpsLoggingService extends Service  {
                     needToStartGpsManager = true;
                 }
 
+                if (bundle.get(IntentConstants.PASSIVE_FILTER_INTERVAL) != null) {
+                    int passiveFilterInterval = bundle.getInt(IntentConstants.PASSIVE_FILTER_INTERVAL);
+                    LOG.debug("Intent received - Set passive filter interval: " + String.valueOf(passiveFilterInterval));
+                    preferenceHelper.setPassiveFilterInterval(passiveFilterInterval);
+                    needToStartGpsManager = true;
+                }
+                
                 if(bundle.get(IntentConstants.LOG_ONCE) != null){
                     boolean logOnceIntent = bundle.getBoolean(IntentConstants.LOG_ONCE);
                     LOG.debug("Intent received - Log Once: " + String.valueOf(logOnceIntent));

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/IntentConstants.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/IntentConstants.java
@@ -31,6 +31,7 @@ public class IntentConstants {
     public static final String GPS_ON_BETWEEN_FIX = "setkeepbetweenfix";
     public static final String RETRY_TIME = "setretrytime";
     public static final String ABSOLUTE_TIMEOUT = "setabsolutetimeout";
+    public static final String PASSIVE_FILTER_INTERVAL = "passivefilterinterval";
     public static final String LOG_ONCE = "logonce";
     public static final String SWITCH_PROFILE = "switchprofile";
     public static final String GET_STATUS = "getstatus";

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceHelper.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceHelper.java
@@ -447,6 +447,21 @@ public class PreferenceHelper {
     public void setAbsoluteTimeoutForAcquiringPosition(int absoluteTimeout) {
         prefs.edit().putString(PreferenceNames.ABSOLUTE_TIMEOUT, String.valueOf(absoluteTimeout)).apply();
     }
+    
+    /**
+     * Reduce redundant passive location updates by adjusting the minimum collection interval (in seconds).
+     */
+    @ProfilePreference(name= PreferenceNames.PASSIVE_FILTER_INTERVAL)
+    public int getPassiveFilterInterval() {
+        return (Strings.toInt(prefs.getString(PreferenceNames.PASSIVE_FILTER_INTERVAL, "1"), 1));
+    }
+
+    /**
+     * Sets Reduce redundant passive location updates by adjusting the minimum collection interval (in seconds).
+     */
+    public void setPassiveFilterInterval(int filterInterval) {
+        prefs.edit().putString(PreferenceNames.PASSIVE_FILTER_INTERVAL, String.valueOf(filterInterval)).apply();
+    }
 
     /**
      * Whether to start logging on application launch

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceNames.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceNames.java
@@ -29,6 +29,7 @@ public  class PreferenceNames {
 
     public static final String LOGGING_RETRY_SHOULD_GET_BEST_POSSIBLE_ACCURACY = "retry_get_best_possible_accuracy";
     public static final String ABSOLUTE_TIMEOUT = "absolute_timeout";
+    public static final String PASSIVE_FILTER_INTERVAL = "passive_filter_interval";
     public static final String START_LOGGING_ON_APP_LAUNCH = "startonapplaunch";
     public static final String STOP_LOGGING_ON_APP_LAUNCH = "stoponapplaunch";
     public static final String START_LOGGING_ON_BOOTUP = "startonbootup";

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/Session.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/Session.java
@@ -264,6 +264,23 @@ public class Session {
     }
 
     /**
+     * Store passive timestamp
+     * @return the latestPassiveTimeStamp (for location info)
+     */
+    public long getLatestPassiveTimeStamp() {
+        return Long.parseLong(get("latestPassiveTimeStamp", "0"));
+    }
+
+    /**
+     * Store passive timestamp
+     * @param latestPassiveTimeStamp the latestPassiveTimeStamp (for location info) to set
+     */
+    public void setLatestPassiveTimeStamp(long latestPassiveTimeStamp) {
+        set("latestPassiveTimeStamp", String.valueOf(latestPassiveTimeStamp));
+    }
+
+
+    /**
      * @return whether to create a new track segment
      */
     public boolean shouldAddNewTrackSegment() {

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/PerformanceSettingsFragment.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/PerformanceSettingsFragment.java
@@ -153,7 +153,8 @@ public class PerformanceSettingsFragment
                     .show(this, PreferenceNames.ABSOLUTE_TIMEOUT);
             return true;
         }
-        
+
+        // passive filter interval dialog
         if(preference.getKey().equalsIgnoreCase(PreferenceNames.PASSIVE_FILTER_INTERVAL)){
             SimpleFormDialog.build()
                     .title(R.string.time_before_logging_dialog_title)
@@ -225,7 +226,8 @@ public class PerformanceSettingsFragment
             findPreference(PreferenceNames.ABSOLUTE_TIMEOUT).setSummary(String.valueOf(preferenceHelper.getAbsoluteTimeoutForAcquiringPosition()) + getString(R.string.seconds));
             return true;
         }
-        
+
+        // passive filter interval dialog callback
         if(dialogTag.equalsIgnoreCase(PreferenceNames.PASSIVE_FILTER_INTERVAL)){
             String time = extras.getString(PreferenceNames.PASSIVE_FILTER_INTERVAL);
             preferenceHelper.setPassiveFilterInterval(Integer.valueOf(time));

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/PerformanceSettingsFragment.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/PerformanceSettingsFragment.java
@@ -57,6 +57,9 @@ public class PerformanceSettingsFragment
 
         findPreference(PreferenceNames.ABSOLUTE_TIMEOUT).setOnPreferenceClickListener(this);
         findPreference(PreferenceNames.ABSOLUTE_TIMEOUT).setSummary(String.valueOf(preferenceHelper.getAbsoluteTimeoutForAcquiringPosition()) + getString(R.string.seconds));
+        
+        findPreference(PreferenceNames.PASSIVE_FILTER_INTERVAL).setOnPreferenceClickListener(this);
+        findPreference(PreferenceNames.PASSIVE_FILTER_INTERVAL).setSummary(String.valueOf(preferenceHelper.getPassiveFilterInterval()) + getString(R.string.seconds));
 
         findPreference(PreferenceNames.ALTITUDE_SUBTRACT_OFFSET).setOnPreferenceClickListener(this);
         findPreference(PreferenceNames.ALTITUDE_SUBTRACT_OFFSET).setSummary(String.valueOf(preferenceHelper.getSubtractAltitudeOffset()) + getString(R.string.meters));
@@ -150,6 +153,22 @@ public class PerformanceSettingsFragment
                     .show(this, PreferenceNames.ABSOLUTE_TIMEOUT);
             return true;
         }
+        
+        if(preference.getKey().equalsIgnoreCase(PreferenceNames.PASSIVE_FILTER_INTERVAL)){
+            SimpleFormDialog.build()
+                    .title(R.string.time_before_logging_dialog_title)
+                    .msg(R.string.passive_filter_time_summary)
+                    .fields(
+                            Input.plain(PreferenceNames.PASSIVE_FILTER_INTERVAL)
+                                    .hint(R.string.time_before_logging_hint)
+                                    .inputType(InputType.TYPE_CLASS_NUMBER)
+                                    .required()
+                                    .text(String.valueOf(preferenceHelper.getPassiveFilterInterval()))
+                                    .max(4)
+                    )
+                    .show(this, PreferenceNames.PASSIVE_FILTER_INTERVAL);
+            return true;
+        }
 
         if(preference.getKey().equalsIgnoreCase(PreferenceNames.ALTITUDE_SUBTRACT_OFFSET)){
             SimpleFormDialog.build()
@@ -204,6 +223,13 @@ public class PerformanceSettingsFragment
             String time = extras.getString(PreferenceNames.ABSOLUTE_TIMEOUT);
             preferenceHelper.setAbsoluteTimeoutForAcquiringPosition(Integer.valueOf(time));
             findPreference(PreferenceNames.ABSOLUTE_TIMEOUT).setSummary(String.valueOf(preferenceHelper.getAbsoluteTimeoutForAcquiringPosition()) + getString(R.string.seconds));
+            return true;
+        }
+        
+        if(dialogTag.equalsIgnoreCase(PreferenceNames.PASSIVE_FILTER_INTERVAL)){
+            String time = extras.getString(PreferenceNames.PASSIVE_FILTER_INTERVAL);
+            preferenceHelper.setPassiveFilterInterval(Integer.valueOf(time));
+            findPreference(PreferenceNames.PASSIVE_FILTER_INTERVAL).setSummary(String.valueOf(preferenceHelper.getPassiveFilterInterval()) + getString(R.string.seconds));
             return true;
         }
 

--- a/gpslogger/src/main/res/values-zh-rCN/strings.xml
+++ b/gpslogger/src/main/res/values-zh-rCN/strings.xml
@@ -251,6 +251,8 @@
     <string name="accuracy_filter_summary">保存某点时要求其所具有的最低精度。不那么精确的点会被丢弃。</string>
     <string name="distance_filter_title">按距离过滤</string>
     <string name="distance_filter_summary">要保存的点和上一个点之间的最小距离；距离太近的话会被丢弃。</string>
+    <string name="passive_filter_time_title">被动日志采集间隔</string>
+    <string name="passive_filter_time_summary">调整日志数据的采集间隔以减少数据的大量产生 单位：秒</string>
     <string name="points">点</string>
     <string name="txt_number_of_points">点数</string>
     <string name="save">保存</string>

--- a/gpslogger/src/main/res/values/strings.xml
+++ b/gpslogger/src/main/res/values/strings.xml
@@ -377,6 +377,8 @@
     <string name="accuracy_filter_summary">The minimum precision required for a point to be saved. Points that aren\'t this accurate will be discarded.</string>
     <string name="distance_filter_title">Distance filter</string>
     <string name="distance_filter_summary">The minimum distance required between current and previous for a point to be saved, otherwise the point will be discarded.</string>
+    <string name="passive_filter_time_title">Passive locations update interval</string>
+    <string name="passive_filter_time_summary">Reduce redundant passive location updates by adjusting the minimum collection interval (in seconds).</string>
     <string name="points">points</string>
     <string name="started_at">started at</string>
     <string name="txt_number_of_points">Number of points</string>

--- a/gpslogger/src/main/res/xml/pref_performance.xml
+++ b/gpslogger/src/main/res/xml/pref_performance.xml
@@ -90,7 +90,18 @@
         android:summary="@string/absolute_timeout_summary"
         android:title="@string/absolute_timeout_title"
         app:iconSpaceReserved="false" />
-
+        
+    <Preference
+        android:defaultValue="1"
+        android:dialogTitle="@string/time_before_logging_dialog_title"
+        android:hint="@string/time_before_logging_hint"
+        android:key="passive_filter_interval"
+        android:maxLength="4"
+        android:numeric="integer"
+        android:summary="@string/passive_filter_time_summary"
+        android:title="@string/passive_filter_time_title"
+        app:iconSpaceReserved="false" />
+        
     <PreferenceCategory
         android:title="Altitude"
         app:iconSpaceReserved="false">


### PR DESCRIPTION
Add passive data collection interval setting to prevent excessive data generation.

[#1211 I've also noticed that passiveLocationManager.requestLocationUpdates allows configuration of the sampling interval. Would it be possible to expose this as an independent configuration parameter?](https://github.com/mendhak/gpslogger/issues/1211#issuecomment-2781602312) 

```
passiveLocationManager.requestLocationUpdates(LocationManager.PASSIVE_PROVIDER, 1000, 0, passiveLocationListener);

passiveLocationManager.requestLocationUpdates(LocationManager.PASSIVE_PROVIDER, interval_time, 0, passiveLocationListener);
```

Attempted to implement interval control via passiveLocationManager.requestLocationUpdates, but discovered passive location updates are system-controlled

[#1201](https://github.com/mendhak/gpslogger/issues/1201#issuecomment-2778771096)

Despite implementing WorkManager's execute-expedited option, the solution remains ineffective due to varying system-level restrictions across devices. The expedited flag shows inconsistent behavior, particularly on:
Affected Systems:
Manufacturer-customized ROMs (especially Chinese OEMs)
Battery-optimized devices (Android 9+ power restrictions)
Background-process-limited OS versions

It just hit me—this solution could resolve these issues at a relatively low cost, while also allowing others to adapt it to their own systems as needed. 😀😀😀😀😀
