### PR TITLE
Add message

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/email/AutoEmailWorker.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/email/AutoEmailWorker.java
@@ -140,6 +140,10 @@ public class AutoEmailWorker extends Worker {
 
             if (writer != null) {
 
+                // Add a Message-ID to the email
+      	        String messageid = UUID.randomUUID().toString() + "@gpslogger>";
+                header.addHeaderField("Message-ID", messageid);
+
                 // Regular email with just a body
                 if (files == null || files.length == 0) {
                     header.addHeaderField("Content-Type", "text/plain; charset=UTF-8");

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/email/AutoEmailWorker.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/email/AutoEmailWorker.java
@@ -141,7 +141,7 @@ public class AutoEmailWorker extends Worker {
             if (writer != null) {
 
                 // Add a Message-ID to the email
-      	        String messageid = UUID.randomUUID().toString() + "@gpslogger>";
+      	        String messageid = "<" + UUID.randomUUID().toString() + "@gpslogger>";
                 header.addHeaderField("Message-ID", messageid);
 
                 // Regular email with just a body


### PR DESCRIPTION
Though optional, every message should include a Message-ID: field.
Moreover, many anti-spam systems rely on it to identify and properly handle emails.