### PR TITLE
Add Mime-version header to email with attachment

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/email/AutoEmailWorker.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/email/AutoEmailWorker.java
@@ -149,8 +149,9 @@ public class AutoEmailWorker extends Worker {
                 // Attach files in a multipart way
                 else {
                     String boundary = UUID.randomUUID().toString().replaceAll("-", "").substring(0, 9);
+                    header.addHeaderField("MIME-Version", "1.0");
                     header.addHeaderField("Content-Type", "multipart/mixed; boundary=" + boundary);
-                    writer.write(header.toString());
+                    writer.write(header.toString();
 
                     writer.write("--" + boundary + "\n");
                     writer.write("Content-Type: text/plain; charset=UTF-8" + "\n\n");

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/email/AutoEmailWorker.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/email/AutoEmailWorker.java
@@ -151,7 +151,7 @@ public class AutoEmailWorker extends Worker {
                     String boundary = UUID.randomUUID().toString().replaceAll("-", "").substring(0, 9);
                     header.addHeaderField("MIME-Version", "1.0");
                     header.addHeaderField("Content-Type", "multipart/mixed; boundary=" + boundary);
-                    writer.write(header.toString();
+                    writer.write(header.toString());
 
                     writer.write("--" + boundary + "\n");
                     writer.write("Content-Type: text/plain; charset=UTF-8" + "\n\n");


### PR DESCRIPTION
Adds a Mime-Version header to the email, following RFC 2045. This is necessary for proper MIME compliance and helps with anti-spam systems.