### PR TITLE
Mime type correction in emails

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/email/AutoEmailWorker.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/email/AutoEmailWorker.java
@@ -149,8 +149,9 @@ public class AutoEmailWorker extends Worker {
                 // Attach files in a multipart way
                 else {
                     String boundary = UUID.randomUUID().toString().replaceAll("-", "").substring(0, 9);
+                    header.addHeaderField("MIME-Version", "1.0");
                     header.addHeaderField("Content-Type", "multipart/mixed; boundary=" + boundary);
-                    writer.write(header.toString());
+                    writer.write(header.toString();
 
                     writer.write("--" + boundary + "\n");
                     writer.write("Content-Type: text/plain; charset=UTF-8" + "\n\n");

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/email/AutoEmailWorker.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/email/AutoEmailWorker.java
@@ -151,7 +151,7 @@ public class AutoEmailWorker extends Worker {
                     String boundary = UUID.randomUUID().toString().replaceAll("-", "").substring(0, 9);
                     header.addHeaderField("MIME-Version", "1.0");
                     header.addHeaderField("Content-Type", "multipart/mixed; boundary=" + boundary);
-                    writer.write(header.toString();
+                    writer.write(header.toString());
 
                     writer.write("--" + boundary + "\n");
                     writer.write("Content-Type: text/plain; charset=UTF-8" + "\n\n");

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/email/AutoEmailWorker.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/email/AutoEmailWorker.java
@@ -220,7 +220,7 @@ public class AutoEmailWorker extends Worker {
             Streams.copyIntoStream(inputStream, outputStream);
 
             writer.write("--" + boundary + "\n");
-            writer.write("Content-Type: application/" + Files.getMimeTypeFromFileName(f.getName()) + "; name=\"" + f.getName() + "\"\n");
+            writer.write("Content-Type: " + Files.getMimeTypeFromFileName(f.getName()) + "; name=\"" + f.getName() + "\"\n");
             writer.write("Content-Disposition: attachment; filename=\"" + f.getName() + "\"\n");
             writer.write("Content-Transfer-Encoding: base64\n\n");
             String encodedFile = Base64.encodeToString(outputStream.toByteArray(), Base64.DEFAULT);


### PR DESCRIPTION
Emails sent by GPSLogger previously used incorrect MIME types, such as Content-Type: application/application/gpx+xml for GPX files or Content-Type: application/application/zip for ZIP files.
This was due to the code appending an extra application/ prefix, even though getMimeTypeFromFileName() already provides it.