### PR TITLE
Close download dialog after exception

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/GpsMainActivity.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/GpsMainActivity.java
@@ -1780,10 +1780,15 @@ public class GpsMainActivity extends AppCompatActivity
             EventBus.getDefault().post(new ProfileEvents.PopulateProfiles());
 
 
-        } catch (Exception e) {
+        } catch (final Exception e) {
             LOG.error("Could not download properties file", e);
-            Dialogs.hideProgress();
-            Dialogs.showError("Could not download properties file","Could not download properties file",e.getMessage(), e, this);
+            runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    Dialogs.hideProgress();
+                    Dialogs.showError("Could not download properties file", "Could not download properties file", e.getMessage(), e, GpsMainActivity.this);
+                }
+            });
         }
 
     }


### PR DESCRIPTION
Run profile download UI updates on the main thread to prevent UI freeze.