### PR TITLE
Fix faulty GPS timestamps immediately on entry

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/GpsLoggingService.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/GpsLoggingService.java
@@ -951,6 +951,8 @@ public class GpsLoggingService extends Service  {
             return;
         }
 
+        loc = Locations.getLocationAdjustedForGPSWeekRollover(loc);
+
         boolean isPassiveLocation = loc.getExtras().getBoolean(BundleConstants.PASSIVE);
         long currentTimeStamp = System.currentTimeMillis();
 
@@ -1101,7 +1103,6 @@ public class GpsLoggingService extends Service  {
         LOG.debug(String.valueOf(loc.getLatitude()) + "," + String.valueOf(loc.getLongitude()));
         LOG.info(SessionLogcatAppender.MARKER_LOCATION, getLocationDisplayForLogs(loc));
         loc = Locations.getLocationWithAdjustedAltitude(loc, preferenceHelper);
-        loc = Locations.getLocationAdjustedForGPSWeekRollover(loc);
         resetCurrentFileName(false);
         session.setLatestTimeStamp(System.currentTimeMillis());
         session.setFirstRetryTimeStamp(0);


### PR DESCRIPTION
Applying the rollover correction at the entry of the method is necessary to:

• Prevent false "stale location" discards: If a location with correct time (e.g., from Network provider) is recorded first, subsequent GPS points with rollover issues (reporting ~19.6 years in the past) are discarded as "stale" before they ever reach the correction logic at the end of the method.

• Fix logging stalls: Ensures that all subsequent filters (logging intervals, distance checks, and accuracy) operate on corrected, current-day timestamps.

• Support faulty hardware: Specifically fixes "stuck" logging on devices with faulty GNSS firmwares (such as the Note 8) where GPS time jumps to the past after the initial fix.