### PR TITLE
Do not display passwords in plaintext

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceHelper.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceHelper.java
@@ -677,7 +677,6 @@ public class PreferenceHelper {
         prefs.edit().putString(PreferenceNames.LOG_TO_URL_BASICAUTH_USERNAME, username).apply();
     }
 
-    @ProfilePreference(name=PreferenceNames.LOG_TO_URL_BASICAUTH_PASSWORD)
     public String getCustomLoggingBasicAuthPassword() {
         return prefs.getString(PreferenceNames.LOG_TO_URL_BASICAUTH_PASSWORD, "");
     }

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/CustomUrlFragment.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/ui/fragments/settings/CustomUrlFragment.java
@@ -179,7 +179,6 @@ public class CustomUrlFragment extends PreferenceFragmentCompat implements
                             Input.plain(PreferenceNames.LOG_TO_URL_BASICAUTH_PASSWORD)
                                     .text(preferenceHelper.getCustomLoggingBasicAuthPassword())
                                     .hint(R.string.autoftp_password)
-                                    .showPasswordToggle()
                                     .inputType(InputType.TYPE_TEXT_VARIATION_PASSWORD)
                     )
                     .show(this,PreferenceNames.LOG_TO_URL_BASICAUTH_USERNAME);


### PR DESCRIPTION
These changes align with the discussion in [PR 1300](https://github.com/mendhak/gpslogger/pull/1300) to prioritize security and reduce the risk of plaintext password exposure, both on the device UI and via exported profile files.