### PR TITLE
Fix Basic Auth passwords leaking across profiles

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceHelper.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/PreferenceHelper.java
@@ -675,6 +675,7 @@ public class PreferenceHelper {
         prefs.edit().putString(PreferenceNames.LOG_TO_URL_BASICAUTH_USERNAME, username).apply();
     }
 
+    @ProfilePreference(name=PreferenceNames.LOG_TO_URL_BASICAUTH_PASSWORD)
     public String getCustomLoggingBasicAuthPassword() {
         return prefs.getString(PreferenceNames.LOG_TO_URL_BASICAUTH_PASSWORD, "");
     }
@@ -778,6 +779,7 @@ public class PreferenceHelper {
     /**
      * HTTP File upload password
      */
+    @ProfilePreference(name=PreferenceNames.HTTPFILEUPLOAD_BASICAUTH_PASSWORD)
     public String getHttpFileUploadPassword() {
         return prefs.getString(PreferenceNames.HTTPFILEUPLOAD_BASICAUTH_PASSWORD, "");
     }
@@ -1434,8 +1436,10 @@ public class PreferenceHelper {
                     Object val = m.invoke(this);
 
                     if(val != null){
-                        props.setProperty(((ProfilePreference)a).name(),String.valueOf(val));
-                        LOG.debug(((ProfilePreference) a).name() + " : " + String.valueOf(val));
+                        String preferenceName = ((ProfilePreference) a).name();
+                        props.setProperty(preferenceName, String.valueOf(val));
+                        boolean isSensitive = preferenceName.toLowerCase().contains("password");
+                        LOG.debug(preferenceName + " : " + (isSensitive ? "********" : String.valueOf(val)));
                     }
                     else {
                         LOG.debug("Null value: " + ((ProfilePreference) a).name() + " is null.");


### PR DESCRIPTION
Fixes #1320.

Profile switching only saves/restores getters annotated `@ProfilePreference` in `PreferenceHelper.java` (see `savePropertiesFromPreferences` / `setPreferenceFromPropertiesFile`) - everything else stays on the single shared `SharedPreferences` store and ignores profile switches.

Commit [345e992](https://github.com/mendhak/gpslogger/commit/345e992) removed that annotation from `getCustomLoggingBasicAuthPassword()`, while the username getter right next to it kept its annotation - that's why the password bleeds across profiles but the username doesn't.

This PR:
- Restores `@ProfilePreference` on `getCustomLoggingBasicAuthPassword()`.
- Adds the same annotation to `getHttpFileUploadPassword()`, which has the identical gap (same root cause, just hadn't reported it yet).
- Fixes the actual plaintext-logging concern by redacting any preference whose name contains "password" in the `LOG.debug` call, instead of excluding it from profile scoping.