### PR TITLE
BUGFIX: Prevent false errors on profile change & send correct battery info

### DIFF
--- a/gpslogger/src/main/java/com/mendhak/gpslogger/common/SerializableFIFOBuffer.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/common/SerializableFIFOBuffer.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 
 import java.io.*;
 import java.lang.reflect.Type;
-import java.util.ArrayDeque;
+import java.util.*;
 
 /**
  * Generic FIFO Buffer with file persistence
@@ -37,23 +37,39 @@ public class SerializableFIFOBuffer<T extends Serializable> {
     private ArrayDeque<T> buffer = new ArrayDeque<>();
     private static final Logger LOG = Logs.of(SerializableFIFOBuffer.class);
     private final File persistenceFile;
+    private static final Map<String, SerializableFIFOBuffer<? extends Serializable>> instance = new HashMap<>();
 
 
-    public SerializableFIFOBuffer(String filePath) {
+    private SerializableFIFOBuffer(String filePath) {
         persistenceFile = new File(filePath);
         try {
             if (persistenceFile.exists() && persistenceFile.isFile() && persistenceFile.length() > 0) {
+                LOG.debug("Load FIFO buffer from file: {}", persistenceFile.getAbsolutePath());
                 loadFromFile();
             } else {
                 if (!(persistenceFile.exists() && persistenceFile.isFile())) {
+                    LOG.debug("FIFO buffer file does not exist, creating new file in path: {}", persistenceFile.getAbsolutePath());
                     if (!persistenceFile.createNewFile()) {
-                        throw new RuntimeException("Could not create file " + persistenceFile.getAbsolutePath());
+                        // Only warn, if no exception is thrown the file exists but was falsely not detected by the if-clause
+                        LOG.warn("Could not create file for FIFO buffer in path (already exists): {}", persistenceFile.getAbsolutePath());
                     }
+                } else {
                     LOG.debug("Persistence file for FIFO-buffer is empty");
                 }
             }
         } catch (IOException e) {
-            LOG.error("Error on creation of FIFO buffer for Dawarich logging, logging will not function", e);
+            LOG.error("Error on creation of FIFO buffer for Dawarich logging, logging will not be functional", e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Serializable> SerializableFIFOBuffer<T> getInstance(String filePath) {
+        if (instance.containsKey(filePath)) {
+            return (SerializableFIFOBuffer<T>) instance.get(filePath);
+        } else {
+            SerializableFIFOBuffer<T> newInst = new SerializableFIFOBuffer<>(filePath);
+            instance.put(filePath, newInst);
+            return newInst;
         }
     }
 

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/dawarich/DawarichLogger.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/loggers/dawarich/DawarichLogger.java
@@ -5,14 +5,12 @@ import com.mendhak.gpslogger.common.*;
 import com.mendhak.gpslogger.loggers.FileLogger;
 import com.mendhak.gpslogger.senders.dawarich.DawarichManager;
 
-import java.io.IOException;
-
 public class DawarichLogger implements FileLogger {
 
     private final SerializableFIFOBuffer<SerializableLocation> buffer;
 
     public DawarichLogger (String persistenceFilePath) {
-        this.buffer = new SerializableFIFOBuffer<>(persistenceFilePath + "/buffer.json");
+        this.buffer = SerializableFIFOBuffer.getInstance(persistenceFilePath + "/buffer.json");
     }
 
     @Override

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/dawarich/DawarichBatchLocation.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/dawarich/DawarichBatchLocation.java
@@ -19,12 +19,10 @@
 
 package com.mendhak.gpslogger.senders.dawarich;
 
-import com.mendhak.gpslogger.common.BundleConstants;
-import com.mendhak.gpslogger.common.PreferenceHelper;
-import com.mendhak.gpslogger.common.SerializableLocation;
-import com.mendhak.gpslogger.common.Strings;
+import android.content.Context;
+import com.mendhak.gpslogger.common.*;
+import com.mendhak.gpslogger.common.BatteryInfo;
 import com.mendhak.gpslogger.common.slf4j.Logs;
-import net.openid.appauth.internal.Logger;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -236,17 +234,25 @@ public class DawarichBatchLocation {
         this.battery_level = builder.battery_level;
     }
 
-    public static DawarichBatchLocation fromSerializableLocation (SerializableLocation location) {
+    public static DawarichBatchLocation fromSerializableLocation (Context context, SerializableLocation location) {
         sourceData = location;
         double[] coords = {location.getLongitude(), location.getLatitude()};
+        double batLvl = -1.0;
+        boolean batChg = false;
+        BatteryInfo batteryInfo = Systems.getBatteryInfo(context);
+        batLvl = batteryInfo.BatteryLevel;
+        batChg = batteryInfo.IsCharging;
         Builder b = new Builder(coords, Strings.getIsoDateTimeWithOffset(new Date(location.getTime())))
                 .withAltitude(location.getAltitude())
                 .withSpeed(location.getSpeed())
                 // Use accuracy in meters as hor. accuracy
                 .withHorizontalAccuracy(location.getAccuracy())
                 .withLocationsInPayload(1)
-                .withBatteryState(location.getBatteryCharging() ? "charging" : "unplugged")
-                .withBatteryLevel((double) location.getBatteryLevel() / 100);
+                // not clear why data provided by Location is wrong, using implementation from CustomURL
+                //.withBatteryState(location.getBatteryCharging() ? "charging" : "unplugged")
+                //.withBatteryLevel((double) location.getBatteryLevel() / 100)
+                .withBatteryLevel(batLvl)
+                .withBatteryState(batChg ? "charging" : "unplugged");
         if (!Strings.isNullOrEmpty(location.getHDOP()) &&  !Strings.isNullOrEmpty(location.getVDOP())) {
             // Calc vert. accuracy from hor. accuracy, vdop & hdop via acc*(vdop/hdop)
             b.withVerticalAccuracy(location.getAccuracy() * (Double.parseDouble(location.getVDOP()) / Double.parseDouble(location.getHDOP())));
@@ -255,18 +261,27 @@ public class DawarichBatchLocation {
     }
 
     public static DawarichBatchLocation fromSerializableLocationExtended (
+            Context context,
             SerializableLocation location,
             PreferenceHelper helper){
         sourceData = location;
         double[] coords = {location.getLongitude(), location.getLatitude()};
+        double batLvl = -1.0;
+        boolean batChg = false;
+        BatteryInfo batteryInfo = Systems.getBatteryInfo(context);
+        batLvl = batteryInfo.BatteryLevel;
+        batChg = batteryInfo.IsCharging;
         Builder b = new Builder(coords, Strings.getIsoDateTimeWithOffset(new Date(location.getTime())))
                 .withAltitude(location.getAltitude())
                 .withSpeed(location.getSpeed())
                 // Use accuracy in meters as hor. accuracy
                 .withHorizontalAccuracy(location.getAccuracy())
                 .withLocationsInPayload(1)
-                .withBatteryState(location.getBatteryCharging() ? "charging" : "unplugged")
-                .withBatteryLevel((double) location.getBatteryLevel() / 100)
+                // not clear why data provided by Location is wrong, using implementation from CustomURL
+                //.withBatteryState(location.getBatteryCharging() ? "charging" : "unplugged")
+                //.withBatteryLevel((double) location.getBatteryLevel() / 100)
+                .withBatteryLevel(batLvl)
+                .withBatteryState(batChg ? "charging" : "unplugged")
                 .withDeferred(helper.getMinimumDistanceInterval())
                 .withDesiredAccuracy(helper.getMinimumAccuracy())
                 .withDeviceId(helper.getDawarichDeviceId())

--- a/gpslogger/src/main/java/com/mendhak/gpslogger/senders/dawarich/DawarichWorker.java
+++ b/gpslogger/src/main/java/com/mendhak/gpslogger/senders/dawarich/DawarichWorker.java
@@ -42,7 +42,7 @@ public class DawarichWorker extends Worker {
 
         DawarichBatch batch = new DawarichBatch();
         while (!buffer.isEmpty()) {
-            DawarichBatchLocation loc = DawarichBatchLocation.fromSerializableLocationExtended(Objects.requireNonNull(buffer.pop()), preferenceHelper);
+            DawarichBatchLocation loc = DawarichBatchLocation.fromSerializableLocationExtended(this.getApplicationContext(), Objects.requireNonNull(buffer.pop()), preferenceHelper);
             batch.appendLocation(loc);
         }
         try {


### PR DESCRIPTION
When changing profiles the FIFO buffer often throws false errors because of problems with file detection.
Therefor I changed from exception to LOG.warn (because the test throws an exception itself if necessary) and added an instance handling to SerializableFIFOBuffer.

Also added battery info as used in CustomURL, as info provided by Location is inaccurate / wrong.